### PR TITLE
Replaced <a> with <button> on docs site.

### DIFF
--- a/source/site/partials/code-snippet.hbs
+++ b/source/site/partials/code-snippet.hbs
@@ -1,4 +1,4 @@
-{{#if button}}<a href="#" class="button" data-toggle-visible="#{{id}}">{{button}}</a>{{/if}}
+{{#if button}}<button class="button" data-toggle-visible="#{{id}}">{{button}}</button>{{/if}}
 {{! if path is there then we load the file and escape in path otherwise we lookup a file called id.lang (index.html,
     test.js etc.) }}
 <pre id="{{id}}"><code class="{{lang}}">{{#if path}}{{glob path}}{{else}}{{glob (snippetPath id lang)}}{{/if}}</code></pre>


### PR DESCRIPTION
Changed element for better semantics and keyboard support under OSX. Resolves issue #19.
