### PR TITLE
Matching responsive scale between docs and code

### DIFF
--- a/source/site/data/pages/getting-started.yml
+++ b/source/site/data/pages/getting-started.yml
@@ -175,6 +175,9 @@ sections:
                         - Ratio
                       rows:
                         -
+                          - .ct-square
+                          - '1'
+                        -
                           - .ct-minor-second
                           - '15:16'
                         -

--- a/source/styles/settings/_chartist-settings.scss
+++ b/source/styles/settings/_chartist-settings.scss
@@ -1,6 +1,6 @@
 // Scales for responsive SVG containers
-$ct-scales: ((3/4), (1/1.618), (9/16), 1, (1/2), (1/3), (1/4)) !default;
-$ct-scales-names: (ct-perfect-fourth, ct-golden-section, ct-minor-seventh, ct-square, ct-octave, ct-major-twelfth, ct-double-octave) !default;
+$ct-scales: ((1), (15/16), (8/9), (5/6), (4/5), (3/4), (2/3), (5/8), (1/1.618), (3/5), (9/16), (8/15), (1/2), (2/5), (3/8), (1/3), (1/4)) !default;
+$ct-scales-names: (ct-square, ct-minor-second, ct-major-second, ct-minor-third, ct-major-third, ct-perfect-fourth, ct-perfect-fifth, ct-minor-sixth, ct-golden-section, ct-major-sixth, ct-minor-seventh, ct-major-seventh, ct-octave, ct-major-tenth, ct-major-eleventh, ct-major-twelfth, ct-double-octave) !default;
 
 // Class names to be used when generating CSS
 $ct-class-chart: ct-chart !default;


### PR DESCRIPTION
I noticed that about half of the documented responsive scales weren't actually in the code (and the code had ct-square which wasn't in the documentation).

This is only fixed in the .scss and the yml. Not in the .css
