### PR TITLE
Add bower install to contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ with a fix.
 
 1. `cd` into your local copy of the repository.
 2. Run `npm install` to install dependencies located in `package.json`.
-3. Run `bower update` to install bower dependencies.
+3. Run `sudo npm install bower -g` to install bower (admin privlages required).
+4. Run `bower update` to install bower dependencies.
 5. Run `grunt serve` to start the watch task, and the web server should automatically open. Congrats, you should now be able to see your local copy of the demo site.
 
 ## <a name="submit"></a> Submission Guidelines


### PR DESCRIPTION
Just something small I came across when following the setup instructions after a clean OS X install.

J&
