### PR TITLE
Fix for donut chart when a series only has one non-zero value

### DIFF
--- a/source/scripts/chartist.pie.js
+++ b/source/scripts/chartist.pie.js
@@ -166,6 +166,9 @@
         y: chartRect.y2 + chartRect.height() / 2
       };
 
+      // Check if there is only one non-zero value in the series array.
+      var hasSingleValInSeries = data.series.filter(function(val) { return val !== 0; }).length === 1;
+
       // Draw the series
       // initialize series groups
       for (var i = 0; i < data.series.length; i++) {
@@ -191,7 +194,7 @@
           endAngle -= 0.01;
         }
 
-        var start = Chartist.polarToCartesian(center.x, center.y, radius, startAngle - (i === 0 ? 0 : 0.2)),
+        var start = Chartist.polarToCartesian(center.x, center.y, radius, startAngle - (i === 0 || hasSingleValInSeries ? 0 : 0.2)),
           end = Chartist.polarToCartesian(center.x, center.y, radius, endAngle),
           arcSweep = endAngle - startAngle <= 180 ? '0' : '1',
           d = [

--- a/source/scripts/chartist.pie.js
+++ b/source/scripts/chartist.pie.js
@@ -167,7 +167,9 @@
       };
 
       // Check if there is only one non-zero value in the series array.
-      var hasSingleValInSeries = data.series.filter(function(val) { return val !== 0; }).length === 1;
+      var hasSingleValInSeries = data.series.filter(function(val) { 
+        return val !== 0; 
+      }).length === 1;
 
       // Draw the series
       // initialize series groups


### PR DESCRIPTION
If a data series had only one non-zero value that was not the first element, such as [0, 0, 23, 0, 0], it would incorrectly set the startAngle. This fix checks the series first then updates the startAngle calculation to take that into consideration.
