### PR TITLE
change the order between area and line

### DIFF
--- a/dist/chartist.js
+++ b/dist/chartist.js
@@ -1880,7 +1880,23 @@
               pathElements.push('L' + pathCoordinates[l - 1] + ',' + pathCoordinates[l]);
             }
           }
+          
+          if(options.showLine) {
+            var line = seriesGroups[i].elem('path', {
+              d: pathElements.join('')
+            }, options.classNames.line, true).attr({
+              'values': normalizedData[i]
+            }, Chartist.xmlNs.uri);
 
+            this.eventEmitter.emit('draw', {
+              type: 'line',
+              values: normalizedData[i],
+              index: i,
+              group: seriesGroups[i],
+              element: line
+            });
+          }
+          
           if(options.showArea) {
             // If areaBase is outside the chart area (< low or > high) we need to set it respectively so that
             // the area is not drawn outside the chart area.
@@ -1909,22 +1925,6 @@
               index: i,
               group: seriesGroups[i],
               element: area
-            });
-          }
-
-          if(options.showLine) {
-            var line = seriesGroups[i].elem('path', {
-              d: pathElements.join('')
-            }, options.classNames.line, true).attr({
-              'values': normalizedData[i]
-            }, Chartist.xmlNs.uri);
-
-            this.eventEmitter.emit('draw', {
-              type: 'line',
-              values: normalizedData[i],
-              index: i,
-              group: seriesGroups[i],
-              element: line
             });
           }
         }


### PR DESCRIPTION
this way, you can have a stroke for area and also you can see the line above area. in the current version, when you have both strokes the area it overrides the line. which is not good for styling
