### PR TITLE
fix(core) createSvg: add container check before remove

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -165,7 +165,7 @@ var Chartist = {
     height = height || '100%';
 
     svg = container.querySelector('svg');
-    if(svg) {
+    if(svg && container === svg.parentElement) {
       container.removeChild(svg);
     }
 


### PR DESCRIPTION
`svg` could be not direct child of `container`, for example:

``` html
<body>
    <div id="container">
        <svg></svg>
    </div>
</body>
```

``` js
var svg = Chartist.createSvg(document.body)
```

this would fail with:

``` js
 Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```
