### PR TITLE
Only remove chartist svg on createSvg

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "grunt-umd": "~2.2.1",
     "grunt-usemin": "~2.6.2",
     "handlebars-helpers": "~0.5.8",
-    "jasmine-fixture": "~1.2.2",
+    "jasmine-jquery": "~2.0.5",
     "jshint-stylish": "~1.0.0",
     "load-grunt-config": "^0.16.0",
     "lodash": "^2.4.1",

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -164,12 +164,13 @@ var Chartist = {
     width = width || '100%';
     height = height || '100%';
 
-    // Append the className so we only remove the Chartist svg element, not
-    // any other svg elements in the container.
-    svg = container.querySelector('svg.' + className);
-    if (svg) {
+    // Check if there is a previous SVG element in the container that contains the Chartist XML namespace and remove it
+    // Since the DOM API does not support namespaces we need to manually search the returned list http://www.w3.org/TR/selectors-api/
+    Array.prototype.slice.call(container.querySelectorAll('svg')).filter(function filterChartistSvgObjects(svg) {
+      return svg.getAttribute(Chartist.xmlNs.qualifiedName);
+    }).forEach(function removePreviousElement(svg) {
       container.removeChild(svg);
-    }
+    });
 
     // Create svg object with width and height or use 100% as default
     svg = new Chartist.Svg('svg').attr({

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -164,8 +164,10 @@ var Chartist = {
     width = width || '100%';
     height = height || '100%';
 
-    svg = container.querySelector('svg');
-    if(svg) {
+    // Append the className so we only remove the Chartist svg element, not
+    // any other svg elements in the container.
+    svg = container.querySelector('svg.' + className);
+    if (svg) {
       container.removeChild(svg);
     }
 

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -26,7 +26,8 @@ module.exports = function (grunt) {
         specs: '<%= pkg.config.test %>/spec/**/spec-*.js',
         helpers: '<%= pkg.config.test %>/spec/**/helper-*.js',
         vendor: [
-          'http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js'
+          'http://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js',
+          'node_modules/jasmine-jquery/lib/jasmine-jquery.js'
         ],
         phantomjs: {
           'ignore-ssl-errors': true

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -25,6 +25,9 @@ module.exports = function (grunt) {
       options: {
         specs: '<%= pkg.config.test %>/spec/**/spec-*.js',
         helpers: '<%= pkg.config.test %>/spec/**/helper-*.js',
+        vendor: [
+          'http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js'
+        ],
         phantomjs: {
           'ignore-ssl-errors': true
         }

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -11,18 +11,32 @@ describe('Chartist core', function() {
 
   describe('createSvg tests', function () {
     it('should not remove non-chartist svg elements', function() {
-      $('body').append('<div id="chart-container"><svg id="foo"></svg><div><svg id="bar"></svg></div></div>');
+      jasmine.getFixtures().set('<div id="chart-container"><svg id="foo"></svg><div><svg id="bar"></svg></div></div>');
 
       var container = $('#chart-container'),
-        childSvg = $('#chart-container #foo'),
-        nestedChildSvg = $('#chart-container #bar'),
-
         // We use get(0) because we want the DOMElement, not the jQuery object.
         svg = Chartist.createSvg(container.get(0), '500px', '400px', 'ct-fish-bar');
 
       expect(svg).toBeDefined();
-      expect(childSvg.length).toEqual(1);
-      expect(nestedChildSvg.length).toEqual(1);
+      expect(svg.classes()).toContain('ct-fish-bar');
+      expect(container).toContainElement('#foo');
+      expect(container).toContainElement('#bar');
+    });
+
+    it('should remove previous chartist svg elements', function() {
+      jasmine.getFixtures().set('<div id="chart-container"></div>');
+
+      var container = $('#chart-container'),
+        // We use get(0) because we want the DOMElement, not the jQuery object.
+        svg1 = Chartist.createSvg(container.get(0), '500px', '400px', 'ct-fish-bar'),
+        svg2 = Chartist.createSvg(container.get(0), '800px', '200px', 'ct-snake-bar');
+
+      expect(svg1).toBeDefined();
+      expect(svg1.classes()).toContain('ct-fish-bar');
+      expect(svg2).toBeDefined();
+      expect(svg2.classes()).toContain('ct-snake-bar');
+      expect(container).not.toContainElement('.ct-fish-bar');
+      expect(container).toContainElement('.ct-snake-bar');
     });
   });
 });

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -1,0 +1,28 @@
+describe('Chartist core', function() {
+  'use strict';
+
+  beforeEach(function() {
+
+  });
+
+  afterEach(function() {
+
+  });
+
+  describe('createSvg tests', function () {
+    it('should not remove non-chartist svg elements', function() {
+      $('body').append('<div id="chart-container"><svg id="foo"></svg><div><svg id="bar"></svg></div></div>');
+
+      var container = $('#chart-container'),
+        childSvg = $('#chart-container #foo'),
+        nestedChildSvg = $('#chart-container #bar'),
+
+        // We use get(0) because we want the DOMElement, not the jQuery object.
+        svg = Chartist.createSvg(container.get(0), '500px', '400px', 'ct-fish-bar');
+
+      expect(svg).toBeDefined();
+      expect(childSvg.length).toEqual(1);
+      expect(nestedChildSvg.length).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
This is a slightly different take on #142

@gionkunz I tried the approach you mentioned with `container.__chartist__.svg` but couldn't get it to work. When I was running tests for `Chartist.createSvg`, `container.__chartist__` was undefined.

What this does is append the className that is passed to `createSvg` to the `querySelector` for locating the svg element. That way the container may contain other `svg` elements as direct child or children of other nodes.

I added a test for this which required I create a new spec; `spec-core`. I added jQuery to the Jasmine config to make creating and finding DOM elements easier in the specs.

I noticed that `jasmine-fixture` is included in the dependencies, but I could not figure out how to include it in the test runner.
