### PR TITLE
New chart type - LineXY & DateAxis

### DIFF
--- a/src/scripts/axes/date-axis.js
+++ b/src/scripts/axes/date-axis.js
@@ -1,0 +1,45 @@
+/**
+ * Step axis for step based charts like bar chart or step based line chart
+ *
+ * @module Chartist.DateAxis
+ */
+/* global Chartist */
+(function (window, document, Chartist) {
+  'use strict';
+
+  function DateAxis(units, options) {
+    this.units = units;
+    this.counterUnits = units === Chartist.Axis.units.x ? Chartist.Axis.units.y : Chartist.Axis.units.x;
+    this.options = options;
+
+	this.ticksProvider = options.ticksProvider || new ResolutionBasedDateTicksProvider();
+	this.ticks = [];
+  }
+  
+  function initialize(chartRect, transform, labelOffset, highLow) {
+	this.chartRect = chartRect;
+    this.axisLength = chartRect[this.units.rectEnd] - chartRect[this.units.rectStart];
+    this.gridOffset = chartRect[this.units.rectOffset];
+	this.transform = transform;
+	this.labelOffset = labelOffset;
+	
+	
+	this.ticks = this.ticksProvider.getTicks(highLow);
+	this.min = this.ticks[0].valueOf();
+	this.range = this.ticks[this.ticks.length-1].valueOf() - this.min;
+  }
+
+  function projectValue(value) {
+    return {
+      pos: value * (this.axisLength / this.range) - this.min * (this.axisLength / this.range),
+      len: Chartist.projectLength(this.axisLength, 1, this)
+    };
+  }
+
+  Chartist.DateAxis = Chartist.Axis.extend({
+    constructor: DateAxis,
+    projectValue: projectValue,
+	initialize: initialize
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/axes/linear-scale-axis.js
+++ b/src/scripts/axes/linear-scale-axis.js
@@ -20,7 +20,7 @@
 
   function projectValue(value) {
     return {
-      pos: this.axisLength * (value - this.bounds.min) / (this.bounds.range + this.bounds.step),
+      pos: this.units.pos == 'x' ? this.axisLength * (value - this.bounds.low) / (this.bounds.valueRange) : this.axisLength * (value - this.bounds.min) / (this.bounds.range + this.bounds.step),
       len: Chartist.projectLength(this.axisLength, this.bounds.step, this.bounds)
     };
   }

--- a/src/scripts/charts/lineXY.js
+++ b/src/scripts/charts/lineXY.js
@@ -1,0 +1,367 @@
+/**
+ * Line XY Chart.
+ *
+ * 
+ *
+ * @module Chartist.LineXY
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+
+  /**
+   * Default options in line charts. Expand the code view to see a detailed list of options with comments.
+   *
+   * @memberof Chartist.LineXY
+   */
+  var defaultOptions = {
+    // Options for X-Axis
+    axisX: {
+      // The offset of the labels to the chart area
+      offset: 30,
+      // Allows you to correct label positioning on this axis by positive or negative x and y offset.
+      labelOffset: {
+        x: 0,
+        y: 0
+      },
+      // If labels should be shown or not
+      showLabel: true,
+      // If the axis grid should be drawn or not
+      showGrid: true,
+      // Interpolation function that allows you to intercept the value from the axis label
+      labelInterpolationFnc: Chartist.noop
+    },
+    // Options for Y-Axis
+    axisY: {
+      // The offset of the labels to the chart area
+      offset: 40,
+      // Allows you to correct label positioning on this axis by positive or negative x and y offset.
+      labelOffset: {
+        x: 0,
+        y: 0
+      },
+      // If labels should be shown or not
+      showLabel: true,
+      // If the axis grid should be drawn or not
+      showGrid: true,
+      // Interpolation function that allows you to intercept the value from the axis label
+      labelInterpolationFnc: Chartist.noop,
+      // This value specifies the minimum height in pixel of the scale steps
+      scaleMinSpace: 20
+    },
+    // Specify a fixed width for the chart as a string (i.e. '100px' or '50%')
+    width: undefined,
+    // Specify a fixed height for the chart as a string (i.e. '100px' or '50%')
+    height: undefined,
+    // If the line should be drawn or not
+    showLine: true,
+    // If dots should be drawn or not
+    showPoint: true,
+    // If the line chart should draw an area
+    showArea: false,
+    // The base for the area chart that will be used to close the area shape (is normally 0)
+    areaBase: 0,
+    // Specify if the lines should be smoothed (Catmull-Rom-Splines will be used)
+    lineSmooth: true,
+    // Overriding the natural low of the chart allows you to zoom in or limit the charts lowest displayed value
+    low: undefined,
+    // Overriding the natural high of the chart allows you to zoom in or limit the charts highest displayed value
+    high: undefined,
+    // Padding of the chart drawing area to the container element and labels
+    chartPadding: 5,
+    // When set to true, the last grid line on the x-axis is not drawn and the chart elements will expand to the full available width of the chart. For the last label to be drawn correctly you might need to add chart padding or offset the last label with a draw event handler.
+    fullWidth: false,
+    // If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
+    reverseData: false,
+    // Override the class names that get used to generate the SVG structure of the chart
+    classNames: {
+      chart: 'ct-chart-line',
+      label: 'ct-label',
+      labelGroup: 'ct-labels',
+      series: 'ct-series',
+      line: 'ct-line',
+      point: 'ct-point',
+      area: 'ct-area',
+      grid: 'ct-grid',
+      gridGroup: 'ct-grids',
+      vertical: 'ct-vertical',
+      horizontal: 'ct-horizontal'
+    }
+  };
+
+  /**
+   * Creates a new chart
+   *
+   */
+  function createChart(options) {
+    var seriesGroups = [];
+
+    // Create new svg object
+    this.svg = Chartist.createSvg(this.container, options.width, options.height, options.classNames.chart);
+
+    var chartRect = Chartist.createChartRect(this.svg, options);
+	
+	var yValues = [];
+	var xValues = [];
+	
+	this.data.series.forEach(function(series, seriesIndex) {
+		xValues[seriesIndex] = [];
+		yValues[seriesIndex] = [];
+		series[seriesIndex] = [];
+		series[seriesIndex].data = [];
+		series.data.forEach(function(value, valueIndex) {
+			value = this.dataTransform(value);
+			series[seriesIndex].data.push(value);
+			xValues[seriesIndex][valueIndex] = value.x;
+			yValues[seriesIndex][valueIndex] = value.y;
+		}.bind(this));
+	}.bind(this));
+
+    var highLowForY = Chartist.getHighLow(yValues);
+	var highLowForX = Chartist.getHighLow(xValues);
+    // Overrides of high / low from settings
+    highLowForY.high = +options.high || (options.high === 0 ? 0 : highLowForY.high);
+    highLowForY.low = +options.low || (options.low === 0 ? 0 : highLowForY.low);
+	
+	if (this.axisX) {
+          this.axisX.initialize(
+			chartRect, 
+			function xAxisTransform(projectedValue) {
+				projectedValue.pos = chartRect.x1 + projectedValue.pos;
+				return projectedValue;
+			},
+			{
+				x: options.axisX.labelOffset.x,
+				y: chartRect.y1 + options.axisX.labelOffset.y + (this.supportsForeignObject ? 5 : 20)
+		    },
+			highLowForX);
+      }
+
+      if (this.axisY) {
+          this.axisY.initialize(
+		  chartRect,
+		  function yAxisTransform(projectedValue) {
+			projectedValue.pos = chartRect.y1 - projectedValue.pos;
+			return projectedValue;
+		  },
+		  {
+			x: options.chartPadding + options.axisY.labelOffset.x + (this.supportsForeignObject ? -10 : 0),
+			y: options.axisY.labelOffset.y + (this.supportsForeignObject ? -15 : 0)
+		  },
+		  highLowForY);
+      }
+
+    var axisX = this.axisX || new Chartist.LinearScaleAxis(
+      Chartist.Axis.units.x,
+      chartRect,
+	  function xAxisTransform(projectedValue) {
+        projectedValue.pos = chartRect.x1 + projectedValue.pos;
+        return projectedValue;
+      },
+	  {
+        x: options.axisX.labelOffset.x,
+        y: chartRect.y1 + options.axisX.labelOffset.y + (this.supportsForeignObject ? 5 : 20)
+      },
+	  {
+        highLow: highLowForX,
+        scaleMinSpace: options.axisX.scaleMinSpace
+      }
+    );
+
+    var axisY = this.axisY || new Chartist.LinearScaleAxis(
+      Chartist.Axis.units.y,
+      chartRect, 
+	  function yAxisTransform(projectedValue) {
+        projectedValue.pos = chartRect.y1 - projectedValue.pos;
+        return projectedValue;
+      },
+      {
+        x: options.chartPadding + options.axisY.labelOffset.x + (this.supportsForeignObject ? -10 : 0),
+        y: options.axisY.labelOffset.y + (this.supportsForeignObject ? -15 : 0)
+      },
+      {
+        highLow: highLowForY,
+        scaleMinSpace: options.axisY.scaleMinSpace
+      }
+    );
+
+    // Start drawing
+    var labelGroup = this.svg.elem('g').addClass(options.classNames.labelGroup),
+      gridGroup = this.svg.elem('g').addClass(options.classNames.gridGroup);
+
+	var ticksX = axisX.ticks || axisX.bounds.values;
+	var ticksY = axisY.ticks || axisY.bounds.values;
+	
+    Chartist.createAxis(
+      axisX,
+      ticksX,
+      chartRect,
+      gridGroup,
+	  labelGroup,
+      this.supportsForeignObject,
+      options,
+      this.eventEmitter
+    );
+
+    Chartist.createAxis(
+      axisY,
+      ticksY,
+      chartRect,
+      gridGroup,
+      labelGroup,
+      this.supportsForeignObject,
+      options,
+      this.eventEmitter
+    );
+
+    // Draw the series
+    this.data.series.forEach(function(series, seriesIndex) {
+      seriesGroups[seriesIndex] = this.svg.elem('g');
+	  
+      // Write attributes to series group element. If series name or meta is undefined the attributes will not be written
+      seriesGroups[seriesIndex].attr({
+        'series-name': series.name,
+        'meta': Chartist.serialize(series.meta)
+      }, Chartist.xmlNs.uri);
+
+      // Use series class from series data or if not set generate one
+      seriesGroups[seriesIndex].addClass([
+        options.classNames.series,
+        (series.className || options.classNames.series + '-' + Chartist.alphaNumerate(seriesIndex))
+      ].join(' '));
+
+      var pathCoordinates = [];
+	  series.data.forEach(function(value, valueIndex) {
+		value = this.dataTransform(value);
+		var p = {
+		  x: chartRect.x1 + axisX.projectValue(value.x, valueIndex,  series).pos,
+		  y: chartRect.y1 - axisY.projectValue(value.y, valueIndex,  series).pos
+		};
+		pathCoordinates.push(p.x, p.y);
+
+		//If we should show points we need to create them now to avoid secondary loop
+		// Small offset for Firefox to render squares correctly
+		if (options.showPoint) {
+		  var point = seriesGroups[seriesIndex].elem('line', {
+			x1: p.x,
+			y1: p.y,
+			x2: p.x + 0.01,
+			y2: p.y
+		  }, options.classNames.point).attr({
+			'value.x': value.x,
+			'value.y': value.y,
+			'meta': Chartist.getMetaData(series, valueIndex)
+		  }, Chartist.xmlNs.uri);
+
+		  this.eventEmitter.emit('draw', {
+			type: 'point',
+			value: value,
+			index: valueIndex,
+			group: seriesGroups[seriesIndex],
+			element: point,
+			x: p.x,
+			y: p.y
+		  });
+		}
+	  }.bind(this));
+
+      // TODO: Nicer handling of conditions, maybe composition?
+      if (options.showLine || options.showArea) {
+        var path = new Chartist.Svg.Path().move(pathCoordinates[0], pathCoordinates[1]);
+
+        // If smoothed path and path has more than two points then use catmull rom to bezier algorithm
+        if (options.lineSmooth && pathCoordinates.length > 4) {
+
+          var cr = Chartist.catmullRom2bezier(pathCoordinates);
+          for(var k = 0; k < cr.length; k++) {
+            Chartist.Svg.Path.prototype.curve.apply(path, cr[k]);
+          }
+        } else {
+          for(var l = 3; l < pathCoordinates.length; l += 2) {
+            path.line(pathCoordinates[l - 1], pathCoordinates[l]);
+          }
+        }
+
+        if(options.showLine) {
+          var line = seriesGroups[seriesIndex].elem('path', {
+            d: path.stringify()
+          }, options.classNames.line, true).attr({
+            'values': series.data
+          }, Chartist.xmlNs.uri);
+
+          this.eventEmitter.emit('draw', {
+            type: 'line',
+            values: series.data,
+            path: path.clone(),
+            chartRect: chartRect,
+            index: seriesIndex,
+            group: seriesGroups[seriesIndex],
+            element: line
+          });
+        }
+
+        if(options.showArea) {
+          // If areaBase is outside the chart area (< low or > high) we need to set it respectively so that
+          // the area is not drawn outside the chart area.
+          var areaBase = Math.max(Math.min(options.areaBase, axisY.bounds.max), axisY.bounds.min);
+
+          // We project the areaBase value into screen coordinates
+          var areaBaseProjected = chartRect.y1 - axisY.projectValue(areaBase).pos;
+
+          // Clone original path and splice our new area path to add the missing path elements to close the area shape
+          var areaPath = path.clone();
+          // Modify line path and add missing elements for area
+          areaPath.position(0)
+            .remove(1)
+            .move(chartRect.x1, areaBaseProjected)
+            .line(pathCoordinates[0], pathCoordinates[1])
+            .position(areaPath.pathElements.length)
+            .line(pathCoordinates[pathCoordinates.length - 2], areaBaseProjected);
+
+          // Create the new path for the area shape with the area class from the options
+          var area = seriesGroups[seriesIndex].elem('path', {
+            d: areaPath.stringify()
+          }, options.classNames.area, true).attr({
+            'values': series.data
+          }, Chartist.xmlNs.uri);
+
+          this.eventEmitter.emit('draw', {
+            type: 'area',
+            values: series.data,
+            path: areaPath.clone(),
+            chartRect: chartRect,
+            index: seriesIndex,
+            group: seriesGroups[seriesIndex],
+            element: area
+          });
+        }
+      }
+    }.bind(this));
+
+    this.eventEmitter.emit('created', {
+      axisX: axisX,
+	  axisY: axisY,
+      chartRect: chartRect,
+      svg: this.svg,
+      options: options
+    });
+  }
+
+  function LineXY(query, data, options, responsiveOptions, axisX, axisY, dataTransform) {
+    Chartist.LineXY.super.constructor.call(this,
+      query,
+      data,
+      Chartist.extend({}, defaultOptions, options),
+      responsiveOptions);
+	  this.axisX = axisX;
+	  this.axisY = axisY;
+	  this.dataTransform = dataTransform || Chartist.noop;
+  }
+
+  // Creating line chart type in Chartist namespace
+  Chartist.LineXY = Chartist.Base.extend({
+    constructor: LineXY,
+    createChart: createChart
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/date-ticks-provider.js
+++ b/src/scripts/ticks/date/date-ticks-provider.js
@@ -1,0 +1,58 @@
+/**
+ * Date Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.DateTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+	function getTicks(highLow) {
+    		var startDate = highLow.low;
+    		var endDate = highLow.high;
+
+    		var duration = endDate - startDate;
+
+    		var newStart = this.roundDown(new Date(startDate.getTime()));
+    		var newEnd = this.roundUp(new Date(endDate.getTime()));
+
+    		var step = 1;
+    		var startTick = this.getStart(newStart);
+    		var endTick = this.addStep(newEnd, step);
+
+    		var ticks = [];
+    		while(startTick.valueOf() < endTick.valueOf())
+    		{
+    			ticks.push(startTick);
+    			startTick = this.addStep(new Date(startTick.getTime()), step);
+    		}
+    		return ticks;
+    	}
+
+	function addStep(date, step) {
+	}
+
+	function getStart(date) {
+	}
+
+	function roundDown(date) {
+	}
+
+	function roundUp(date) {
+	}
+	
+	function DateTicksProvider() {
+	}
+
+  // Creating date tick provider type in Chartist namespace
+  Chartist.DateTicksProvider = Chartist.Base.extend({
+    constructor: DateTicksProvider,
+    getTicks: getTicks,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/day-ticks-provider.js
+++ b/src/scripts/ticks/date/day-ticks-provider.js
@@ -1,0 +1,43 @@
+/**
+ * Day Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.DayTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+
+  	function addStep(date, step) {
+    	date.setDate(date.getDate() + step);
+		return date;
+	}
+
+	function getStart(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0,0,0,0);
+	}
+
+	function roundDown(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0,0,0,0);
+	}
+
+	function roundUp(date) {
+		var res = roundDown(date);
+		res.setDate(date.getDate() + 1);
+		return res;
+	}
+	
+	function DayTicksProvider() {
+	}
+
+  // Creating day tick provider type in Chartist namespace
+  Chartist.DayTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: DayTicksProvider,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/hour-ticks-provider.js
+++ b/src/scripts/ticks/date/hour-ticks-provider.js
@@ -1,0 +1,43 @@
+/**
+ * Hour Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.HourTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+
+  	function addStep(date, step) {
+    	date.setHours(date.getHours() + step);
+		return date;
+	}
+
+	function getStart(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),0,0,0);
+	}
+
+	function roundDown(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),0,0,0);
+	}
+
+	function roundUp(date) {
+		var res = roundDown(date);
+		res.setHours(date.getHours() + 1);
+		return res;
+	}
+	
+	function HourTicksProvider() {
+	}
+
+  // Creating hour tick provider type in Chartist namespace
+  Chartist.HourTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: HourTicksProvider,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/milliseconds-ticks-provider.js
+++ b/src/scripts/ticks/date/milliseconds-ticks-provider.js
@@ -1,0 +1,44 @@
+/**
+ * Milliseconds Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.MillisecondsTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+
+  	function addStep(date, step) {
+    	date.setMilliseconds(date.getMilliseconds() + step);
+		return date;
+	}
+
+	function getStart(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),date.getMinutes(),date.getSeconds(),date.getMilliseconds());
+	}
+
+	function roundDown(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),date.getMinutes(),date.getSeconds(),date.getMilliseconds());
+	}
+
+	function roundUp(date) {
+    	    var res = roundDown(date);
+			res.setMilliseconds(date.getMilliseconds() + 1);
+    		return res;
+    	}
+	
+	function MillisecondsTicksProvider() {
+	}
+
+  // Creating ms tick provider type in Chartist namespace
+  Chartist.MillisecondsTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: MillisecondsTicksProvider,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+	
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/minute-ticks-provider.js
+++ b/src/scripts/ticks/date/minute-ticks-provider.js
@@ -1,0 +1,43 @@
+/**
+ * Minute Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.MinuteTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+
+  	function addStep(date, step) {
+    	date.setMinutes(date.getMinutes() + step);
+		return date;
+	}
+
+	function getStart(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),date.getMinutes(),0,0);
+	}
+
+	function roundDown(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),date.getMinutes(),0,0);
+	}
+
+	function roundUp(date) {
+		var res = roundDown(date);
+		res.setMinutes(date.getMinutes() + 1);
+		return res;
+	}
+	
+	function MinuteTicksProvider() {
+	}
+
+  // Creating minute tick provider type in Chartist namespace
+  Chartist.MinuteTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: MinuteTicksProvider,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/month-ticks-provider.js
+++ b/src/scripts/ticks/date/month-ticks-provider.js
@@ -1,0 +1,43 @@
+/**
+ * Month Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.MonthTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+  
+  	function addStep(date, step) {
+    	date.setMonth(date.getMonth() + step);
+		return date;
+	}
+
+	function getStart(date) {
+		return new Date(date.getFullYear(), date.getMonth(),  1, 0,0,0,0);
+	}
+
+	function roundDown(date) {
+		return new Date(date.getFullYear(), date.getMonth(),  1, 0,0,0,0);
+	}
+
+	function roundUp(date) {
+		var res = roundDown(date);
+		res.setMonth(date.getMonth() + 1);
+		return res;
+	}
+	
+	function MonthTicksProvider() {
+	}
+
+  // Creating month tick provider type in Chartist namespace
+  Chartist.MonthTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: MonthTicksProvider,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/resolution-based-date-ticks-provider.js
+++ b/src/scripts/ticks/date/resolution-based-date-ticks-provider.js
@@ -1,0 +1,72 @@
+/**
+ * Resolution Based Date Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.ResolutionBasedDateTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+	function getTicks(highLow) {
+    		var startDate = highLow.low;
+    		var endDate = highLow.high;
+
+    		var duration = endDate - startDate;
+    		var bestProvider = getProviderBasedOnDuration(duration);
+
+    		var newStart = bestProvider.roundDown(new Date(startDate.getTime()));
+    		var newEnd = bestProvider.roundUp(new Date(endDate.getTime()));
+
+    		var step = 1;
+    		var startTick = bestProvider.getStart(newStart);
+    		var endTick = bestProvider.addStep(newEnd, step);
+
+    		var ticks = [];
+    		while(startTick.valueOf() < endTick.valueOf())
+    		{
+    			ticks.push(startTick);
+    			startTick = bestProvider.addStep(new Date(startTick.getTime()), step);
+    		}
+    		return ticks;
+    	}
+
+  	function getProviderBasedOnDuration(duration) {
+  		if(duration > 31556952000)
+  		{
+  			return new Chartist.YearTicksProvider();
+  		}
+  		if(duration > 2592000000)
+  		{
+  			return new Chartist.MonthTicksProvider();
+  		}
+  		if(duration > 86400000)
+  		{
+  			return new Chartist.DayTicksProvider();
+  		}
+  		if(duration > 3600000)
+  		{
+  			return new Chartist.HourTicksProvider();
+  		}
+  		if(duration > 60000)
+  		{
+  			return new Chartist.MinuteTicksProvider();
+  		}
+  		if(duration > 1000)
+  		{
+  			return new Chartist.MillisecondsTicksProvider();
+  		}
+
+  		return new Chartist.MillisecondsTicksProvider();
+  	}
+	
+	function ResolutionBasedTicksProvider() {
+	}
+
+  // Creating date tick provider type in Chartist namespace
+  Chartist.ResolutionBasedTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: ResolutionBasedTicksProvider,
+    getTicks: getTicks
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/seconds-ticks-provider.js
+++ b/src/scripts/ticks/date/seconds-ticks-provider.js
@@ -1,0 +1,42 @@
+/**
+ * Seconds Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.SecondsTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+  	function addStep(date, step) {
+    	date.setSeconds(date.getSeconds() + step);
+		return date;
+	}
+
+	function getStart(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),date.getMinutes(),date.getSeconds(),0);
+	}
+
+	function roundDown(date) {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),date.getMinutes(),date.getSeconds(),0);
+	}
+
+	function roundUp(date) {
+		var res = roundDown(date);
+		res.setSeconds(date.getSeconds() + 1);
+		return res;
+	}
+	
+	function SecondsTicksProvider() {
+	}
+
+  // Creating seconds tick provider type in Chartist namespace
+  Chartist.SecondsTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: SecondsTicksProvider,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+  });
+
+}(window, document, Chartist));

--- a/src/scripts/ticks/date/year-ticks-provider.js
+++ b/src/scripts/ticks/date/year-ticks-provider.js
@@ -1,0 +1,42 @@
+/**
+ * Year Ticks Provider
+ *
+ * 
+ *
+ * @module Chartist.YearTicksProvider
+ */
+/* global Chartist */
+(function(window, document, Chartist){
+  'use strict';
+		function addStep(date, step) {
+			date.setFullYear(date.getFullYear() + step);
+			return date;
+    	}
+
+    	function getStart(date) {
+    		return new Date(date.getFullYear(),1, 0,0,0,0,0);
+    	}
+
+    	function roundDown(date) {
+    		 return new Date(date.getFullYear(),1, 0,0,0,0,0);
+    	}
+
+    	function roundUp(date) {
+    	    var res = roundDown(date);
+			res.setFullYear(date.getFullYear() + 1);
+			return res;
+    	}
+	
+	function YearTicksProvider() {
+	}
+
+  // Creating year tick provider type in Chartist namespace
+  Chartist.YearTicksProvider = Chartist.DateTicksProvider.extend({
+    constructor: YearTicksProvider,
+	addStep: addStep,
+	roundDown: roundDown,
+	roundUp: roundUp,
+	getStart: getStart
+  });
+
+}(window, document, Chartist));

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -28,6 +28,7 @@ module.exports = function (grunt) {
           '<%= pkg.config.src %>/scripts/axes/linear-scale-axis.js',
           '<%= pkg.config.src %>/scripts/axes/step-axis.js',
           '<%= pkg.config.src %>/scripts/charts/line.js',
+		  '<%= pkg.config.src %>/scripts/charts/lineXY.js',
           '<%= pkg.config.src %>/scripts/charts/bar.js',
           '<%= pkg.config.src %>/scripts/charts/pie.js'
         ]

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -27,10 +27,21 @@ module.exports = function (grunt) {
           '<%= pkg.config.src %>/scripts/axes/axis.js',
           '<%= pkg.config.src %>/scripts/axes/linear-scale-axis.js',
           '<%= pkg.config.src %>/scripts/axes/step-axis.js',
+          '<%= pkg.config.src %>/scripts/axes/date-axis.js',
           '<%= pkg.config.src %>/scripts/charts/line.js',
-		  '<%= pkg.config.src %>/scripts/charts/lineXY.js',
+          '<%= pkg.config.src %>/scripts/charts/lineXY.js',
           '<%= pkg.config.src %>/scripts/charts/bar.js',
-          '<%= pkg.config.src %>/scripts/charts/pie.js'
+          '<%= pkg.config.src %>/scripts/charts/pie.js',
+          '<%= pkg.config.src %>/scripts/axes/axis.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/date-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/resolution-based-date-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/year-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/month-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/day-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/hour-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/minute-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/seconds-ticks-provider.js',
+          '<%= pkg.config.src %>/scripts/ticks/date/milliseconds-ticks-provider.js',
         ]
       }
     }


### PR DESCRIPTION
New chart type proposition - LineXY and also DateAxis.
### Line XY

``` javascript
function LineXY(query, data, options, responsiveOptions, axisX, axisY, dataTransform)
```

Example to use logarithmic scale:

``` javascript
var logTransform = function(point)
{
    return {
        x: Math.log10(point.x),
        y: point.y
    }
};

var chartlog = new Chartist.LineXY('#chart', chartData, options, responsiveOptions, axisX, axisY, logTransform);
```
### Date Axis

It allows to specify that on axis we have date values. 
We should specify provider to generate ticks:
- ResolutionBasedTicksProvider
- YearTicksProvider
- MonthTicksProvider
- DayTicksProvider
- HourTicksProvider
- MinuteTicksProvider
- SecondsTicksProvider
- MillisecondsTicksProvider

example:

``` javascript
var dateAxis = new Chartist.DateAxis(Chartist.Axis.units.x,{ ticksProvider: new Chartist.ResolutionBasedTicksProvider() });
var chart = new Chartist.LineXY('#chart', chartData, options, undefined, dateAxis);
```
### Examples

[Simple LineXY](http://jsbin.com/depucaxayu/3/edit?js,output)
[Logarithmic Scale](http://jsbin.com/citoyowaho/1/edit?js,output)
[Resolution Based Ticks Provider](http://jsbin.com/jokitubaku/3/edit?js,output)
[Year Ticks Provider](http://jsbin.com/qalohafayu/2/edit?js,output)
[Month Ticks Provider](http://jsbin.com/nijasadona/1/edit?js,output)
[Day Ticks Provider](http://jsbin.com/dunefocati/1/edit?js,output)
[Hour Ticks Provider](http://jsbin.com/jeseqisube/1/edit?js,output)
[Minute Ticks Provider](http://jsbin.com/hamicipoxe/1/edit?js,output)
[Seconds Ticks Provider](http://jsbin.com/novanubivu/1/edit?js,output)
[Milliseconds Ticks Provider](http://jsbin.com/bexovihiri/1/edit?js,output)
