### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to the masses.
 5. Richer Sass / CSS framework
 6. Other charts types (spider etc.)
 
-## Contribution
+## Contribution [![Inline docs](http://inch-ci.org/github/gionkunz/chartist-js.svg?branch=develop)](http://inch-ci.org/github/gionkunz/chartist-js)
 
 We are looking for people who share the idea of having a simple, flexible charting library that is responsive and uses
 modern and future-proof technologies. The goal of this project is to create a responsive charting library where developers


### PR DESCRIPTION
Hi Gion,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/gionkunz/chartist-js.svg)](http://inch-ci.org/github/gionkunz/chartist-js)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs (early adopters include [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [when](https://github.com/cujojs/when)).

The idea is to motivate aspiring Node developers to dive into Open Source projects and read the code.
It's about _engagement_, because, while testing and code coverage are important, inline-docs are the humanly engaging factor in Open Source. This project is about making people less adverse to jumping into the code and see whats happening, because they are not left alone while doing so. I know that, because I put off reading other people's code way too long in my life.

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/gionkunz/chartist-js

What do you think?
