### PR TITLE
Catch failures to get bounding box height / width.

### DIFF
--- a/src/scripts/svg.js
+++ b/src/scripts/svg.js
@@ -314,7 +314,14 @@
    * @return {Number} The elements height in pixels
    */
   function height() {
-    return this._node.clientHeight || Math.round(this._node.getBBox().height) || this._node.parentNode.clientHeight;
+    var h = this._node.clientHeight;
+
+    if (!h) {
+      try { h = Math.round(this._node.getBBox().height); } catch(e) {}
+    }
+
+
+    return h || this._node.parentNode.clientHeight;
   }
 
   /**
@@ -325,7 +332,13 @@
    * @return {Number} The elements width in pixels
    */
   function width() {
-    return this._node.clientWidth || Math.round(this._node.getBBox().width) || this._node.parentNode.clientWidth;
+    var w = this._node.clientWidth;
+
+    if (!w) {
+      try { w = Math.round(this._node.getBBox().width); } catch(e) {}
+    }
+
+    return w || this._node.parentNode.clientWidth;
   }
 
   /**


### PR DESCRIPTION
Using Chartist 0.7.2 in a small React app gives me a somewhat opaque NS_ERROR_FAILURE and no charts rendered in Firefox 35.0.1

This patch catches that error, and makes the charts render correctly.

I'm not seeing the same problem on the Chartist website, so it could be something in React or my code that is the root cause of this. My project is running [here](http://transcripts-staging.holderdeord.no/) if you want to have a look.
