### PR TITLE
add extended 'path' property to data object of pie chart

### DIFF
--- a/dist/chartist.js
+++ b/dist/chartist.js
@@ -3246,6 +3246,7 @@
           index: i,
           group: seriesGroups[i],
           element: path,
+          path: path.clone(),
           center: center,
           radius: radius,
           startAngle: startAngle,


### PR DESCRIPTION
Cloning the path object into a new property when defining the data object on draw will expose the manipulation methods in Chartist.svg.path which are not currently accessible through 'data.element'; the clone will inherit these extended functions however. This approach requires testing.
