### PR TITLE
Update to getting-started.yml

### DIFF
--- a/site/data/pages/getting-started.yml
+++ b/site/data/pages/getting-started.yml
@@ -90,7 +90,7 @@ sections:
             - type: code
               data:
                 lang: bash
-                code: cp bower_components/chartist/libdist/scss/settings/_chartist-settings.scss styles
+                code: cp bower_components/chartist/dist/scss/settings/_chartist-settings.scss styles
 
             - type: text
               data:


### PR DESCRIPTION
After completing the `bower install chartist --save` step, the instructions for setting up _THE SASS WAY_ includes the wrong bash command. This fix is for the listed path to file `_chartist-settings.scss styles`.
