### PR TITLE
Convert string values to numbers

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -331,6 +331,11 @@ var Chartist = {
       } else {
         array[i] = localData;
       }
+      
+      // if value is a string rather than a number (or object), just convert it implicitly
+      if (typeof(array[i]) === 'string') {
+        array[i] = +array[i]
+      }
 
       // Convert object values to numbers
       for (var j = 0; j < array[i].length; j++) {


### PR DESCRIPTION
The API I am using returns strings rather than numbers (so `series: ["1", "2", "3"]), which for some reason is no issue in chrome, but in firefox it throws some cryptic error on this line: https://github.com/gionkunz/chartist-js/blob/develop/src/scripts/core.js#L339

This fixes it. Tested on Chrome, Safari and Firefox.
