### PR TITLE
Added additional check to getHighLow() to support empty charts.

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -100,9 +100,9 @@
         return Array.prototype.slice.call(arguments).reduce(Chartist.sum, 0);
       });
 
-      highLow = Chartist.getHighLow([serialSums]);
+      highLow = Chartist.getHighLow([serialSums], options);
     } else {
-      highLow = Chartist.getHighLow(normalizedData);
+      highLow = Chartist.getHighLow(normalizedData, options);
     }
     // Overrides of high / low from settings
     highLow.high = +options.high || (options.high === 0 ? 0 : highLow.high);

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -103,10 +103,7 @@
 
     var chartRect = Chartist.createChartRect(this.svg, options, defaultOptions.padding);
 
-    var highLow = Chartist.getHighLow(normalizedData);
-    // Overrides of high / low from settings
-    highLow.high = +options.high || (options.high === 0 ? 0 : highLow.high);
-    highLow.low = +options.low || (options.low === 0 ? 0 : highLow.low);
+    var highLow = Chartist.getHighLow(normalizedData, options);
 
     var axisX = new Chartist.StepAxis(
       Chartist.Axis.units.x,

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -435,25 +435,43 @@ var Chartist = {
    *
    * @memberof Chartist.Core
    * @param {Array} dataArray The array that contains the data to be visualized in the chart
+   * @param {Object} options The Object that contains all the optional values for the chart
    * @return {Object} An object that contains the highest and lowest value that will be visualized on the chart.
    */
-  Chartist.getHighLow = function (dataArray) {
+  Chartist.getHighLow = function (dataArray, options) {
     var i,
       j,
       highLow = {
-        high: -Number.MAX_VALUE,
-        low: Number.MAX_VALUE
-      };
+        high: options.high === undefined ? -Number.MAX_VALUE : +options.high,
+        low: options.low === undefined ? Number.MAX_VALUE : +options.low
+      },
+      findHigh = options.high === undefined,
+      findLow = options.low === undefined;
 
     for (i = 0; i < dataArray.length; i++) {
       for (j = 0; j < dataArray[i].length; j++) {
-        if (dataArray[i][j] > highLow.high) {
+        if (findHigh && dataArray[i][j] > highLow.high) {
           highLow.high = dataArray[i][j];
         }
 
-        if (dataArray[i][j] < highLow.low) {
+        if (findLow && dataArray[i][j] < highLow.low) {
           highLow.low = dataArray[i][j];
         }
+      }
+    }
+
+    // If high and low are the same because of misconfiguration or flat data (only the same value) we need
+    // to set the high or low to 0 depending on the polarity
+    if (highLow.high <= highLow.low) {
+      // If both values are 0 we set high to 1
+      if (highLow.low === 0) {
+        highLow.high = 1;
+      } else if (highLow.low < 0) {
+        // If we have the same negative value for the bounds we set bounds.high to 0
+        highLow.high = 0;
+      } else {
+        // If we have the same positive value for the bounds we set bounds.low to 0
+        highLow.low = 0;
       }
     }
 
@@ -478,21 +496,6 @@ var Chartist = {
         high: highLow.high,
         low: highLow.low
       };
-
-    // If high and low are the same because of misconfiguration or flat data (only the same value) we need
-    // to set the high or low to 0 depending on the polarity
-    if(bounds.high === bounds.low) {
-      // If both values are 0 we set high to 1
-      if(bounds.low === 0) {
-        bounds.high = 1;
-      } else if(bounds.low < 0) {
-        // If we have the same negative value for the bounds we set bounds.high to 0
-        bounds.high = 0;
-      } else {
-        // If we have the same positive value for the bounds we set bounds.low to 0
-        bounds.low = 0;
-      }
-    }
 
     // Overrides of high / low based on reference value, it will make sure that the invisible reference value is
     // used to generate the chart. This is useful when the chart always needs to contain the position of the


### PR DESCRIPTION
Without this check the browser freezes (endless loop in Chartist.getBounds() function) with input data:

```
data = {
      labels: [],
      series: []
    }
```

I know, it would also be possible to check  `dataArray.length === 0`, but I overwrite Chartist.normalizeDataArray:

```
Chartist.normalizeDataArray = function (dataArray) {
  return dataArray;
};
```

(in order to support "incomplete" series.
