### PR TITLE
Fixed area path end vertically

### DIFF
--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -267,7 +267,7 @@
           .move(chartRect.x1, areaBaseProjected)
           .line(pathCoordinates[0], pathCoordinates[1])
           .position(areaPath.pathElements.length)
-          .line(pathCoordinates[pathCoordinates.length - 2], areaBaseProjected);
+          .line(areaPath.pathElements[areaPath.pathElements.length - 1].x, areaBaseProjected);
 
         // Create the new path for the area shape with the area class from the options
         var area = seriesGroups[seriesIndex].elem('path', {


### PR DESCRIPTION
``` js
new Chartist.Line('.ct-chart', {
  labels: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
  series: [
    [5, 9, 7, 8, 5, 3, 5, 4]
  ]
}, {
  low: 0,
  showArea: true
});
```

before
![2015-06-02 19 49 26](https://cloud.githubusercontent.com/assets/435105/7934245/8e6a79d8-0960-11e5-894c-870452623d1e.png)

after
![2015-06-02 19 48 42](https://cloud.githubusercontent.com/assets/435105/7934249/984ab7b0-0960-11e5-8e34-bf64213752fd.png)
