### PR TITLE
Changed getChartRects width/height calculation to use the correct axis

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -718,8 +718,8 @@ var Chartist = {
     var normalizedPadding = Chartist.normalizePadding(options.chartPadding, fallbackPadding);
 
     // If settings were to small to cope with offset (legacy) and padding, we'll adjust
-    width = Math.max(width, (options.horizontalBar ? yAxisOffset : xAxisOffset) + normalizedPadding.left + normalizedPadding.right);
-    height = Math.max(height, (options.horizontalBar ? xAxisOffset : yAxisOffset) + normalizedPadding.top + normalizedPadding.bottom);
+    width = Math.max(width, yAxisOffset + normalizedPadding.left + normalizedPadding.right);
+    height = Math.max(height, xAxisOffset + normalizedPadding.top + normalizedPadding.bottom);
 
     var chartRect = {
       padding: normalizedPadding,

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -718,8 +718,8 @@ var Chartist = {
     var normalizedPadding = Chartist.normalizePadding(options.chartPadding, fallbackPadding);
 
     // If settings were to small to cope with offset (legacy) and padding, we'll adjust
-    width = Math.max(width, xAxisOffset + normalizedPadding.left + normalizedPadding.right);
-    height = Math.max(height, yAxisOffset + normalizedPadding.top + normalizedPadding.bottom);
+    width = Math.max(width, (options.horizontalBar ? yAxisOffset : xAxisOffset) + normalizedPadding.left + normalizedPadding.right);
+    height = Math.max(height, (options.horizontalBar ? xAxisOffset : yAxisOffset) + normalizedPadding.top + normalizedPadding.bottom);
 
     var chartRect = {
       padding: normalizedPadding,


### PR DESCRIPTION
Fixes #347 

It seems the `getChartRects` call does not take into account `options.horizontalBar` and compares against the wrong axis. This change just makes sure it compares against the right axis when determining the height of the chart.
