### PR TITLE
Add support for "low" option to Bar chart.

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -170,7 +170,7 @@
 
       valueAxis = axisX = new Chartist.AutoScaleAxis(Chartist.Axis.units.x, data, chartRect, Chartist.extend({}, options.axisX, {
         highLow: highLow,
-        referenceValue: 0
+        referenceValue: options.low || 0
       }));
     } else {
       labelAxis = axisX = new Chartist.StepAxis(Chartist.Axis.units.x, data, chartRect, {
@@ -179,12 +179,13 @@
 
       valueAxis = axisY = new Chartist.AutoScaleAxis(Chartist.Axis.units.y, data, chartRect, Chartist.extend({}, options.axisY, {
         highLow: highLow,
-        referenceValue: 0
+        referenceValue: options.low || 0
       }));
     }
 
     // Projected 0 point
-    var zeroPoint = options.horizontalBars ? (chartRect.x1 + valueAxis.projectValue(0)) : (chartRect.y1 - valueAxis.projectValue(0));
+    var relativeZero = valueAxis.bounds.min > 0 ? valueAxis.bounds.min : 0;
+    var zeroPoint = options.horizontalBars ? (chartRect.x1 + valueAxis.projectValue(relativeZero)) : (chartRect.y1 - valueAxis.projectValue(relativeZero));
     // Used to track the screen coordinates of stacked bars
     var stackedBarValues = [];
 


### PR DESCRIPTION
Currently bar.js has a hard coded referenceValue = 0 when creating the axis. This prevents positive "low" values from being specified and allowing you to zoom-in on the graph as the documentation suggests.

I have made changes to allow the referenceValue to be overriden by the "low" option if specified, thus allowing the value axis to start from values other than zero.
