### PR TITLE
IE9 Working by Default

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -887,7 +887,7 @@ var Chartist = {
       var previousOptions = currentOptions;
       currentOptions = Chartist.extend({}, baseOptions);
 
-      if (responsiveOptions) {
+      if (window.matchMedia && responsiveOptions) {
         for (i = 0; i < responsiveOptions.length; i++) {
           var mql = window.matchMedia(responsiveOptions[i][0]);
           if (mql.matches) {
@@ -910,9 +910,8 @@ var Chartist = {
       });
     }
 
-    if (!window.matchMedia) {
-      throw 'window.matchMedia not found! Make sure you\'re using a polyfill.';
-    } else if (responsiveOptions) {
+
+    if (window.matchMedia && responsiveOptions) {
 
       for (i = 0; i < responsiveOptions.length; i++) {
         var mql = window.matchMedia(responsiveOptions[i][0]);


### PR DESCRIPTION
By default responsive charts don't work in IE9 this fixes that issue. Instead of throwing error or trying to use 

``` javascript
window.matchMedia
```

without testing it's availability first.

This is my first ever GitHub contribution I hope I'm doing it right. :heart: :+1: 
