### PR TITLE
Display the last tick on FixedScaleAxis

### DIFF
--- a/src/scripts/axes/fixed-scale-axis.js
+++ b/src/scripts/axes/fixed-scale-axis.js
@@ -24,7 +24,7 @@
   function FixedScaleAxis(axisUnit, data, chartRect, options) {
     var highLow = options.highLow || Chartist.getHighLow(data.normalized, options, axisUnit.pos);
     this.divisor = options.divisor || 1;
-    this.ticks = options.ticks || Chartist.times(this.divisor).map(function(value, index) {
+    this.ticks = options.ticks || Chartist.times(this.divisor + 1).map(function(value, index) {
       return highLow.low + (highLow.high - highLow.low) / this.divisor * index;
     }.bind(this));
     this.range = {


### PR DESCRIPTION
When using `Bar` graphs with `Chartist.FixedScaleAxis` and a specified
`divisor` option, the last tick is not displayed. E.g:

With `divisor = 12` and `max(series) = 96`, the calculated graph ticks are
`[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88]`

There are indeed 12 ticks, but arguably we don't want to count 0 as a
tick. With the proposed change it would also display 96 at the end of
the axis:

`[0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96]`
