### PR TITLE
Added Chartist fill donut plugin to documentation site

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "chartist-plugin-tooltip": "~0.0.8",
     "chartist-plugin-axistitle": "~0.0.1",
     "chartist-plugin-threshold": "~0.0.1",
+    "chartist-plugin-fill-donut": "~0.0.1",
     "matchMedia": "~0.2.0"
   },
   "ignore": [

--- a/site/data/pages/plugins.yml
+++ b/site/data/pages/plugins.yml
@@ -228,6 +228,32 @@ sections:
                   -
                     - '<strong>Link:</strong>'
                     - '<a href="https://github.com/gionkunz/chartist-plugin-threshold" target="_blank">chartist-plugin-threshold</a>'
+      - type: sub-section
+        data:
+          title: FillDonut Plugin
+          level: 4
+          items:
+            - type: text
+              data:
+                text: >
+                        Let animated donuts look filled and provide options for append labels and html to the donut chart.
+                        This plugin draw the donut a second time but without delay and animation, so it animation will overlaps and looks like the fill the donut.
+                        Also your a possible to add multiple html-labels to the donut on different positions.
+            - type: live-example
+              data:
+                id: example-plugin-fill-donut
+                classes: ct-golden-section
+                intro: >
+                          Let animated donuts look filled and provide options for append labels and html to the donut chart.
+            - type: table
+              data:
+                rows:
+                  -
+                    - '<strong>Author:</strong>'
+                    - Moxx
+                  -
+                    - '<strong>Link:</strong>'
+                    - '<a href="https://github.com/gionkunz/chartist-plugin-threshold" target="_blank">chartist-plugin-threshold</a>'
   - title: Develop a plugin
     level: 3
     items:

--- a/site/examples/example-plugin-fill-donut.js
+++ b/site/examples/example-plugin-fill-donut.js
@@ -1,0 +1,56 @@
+var chart = new Chartist.Pie('.ct-chart', 
+    {
+        series: [160, 60 ],
+        labels: ['', '']
+    }, {
+        donut: true,
+        donutWidth: 20,
+        startAngle: 210,
+        total: 260,
+        showLabel: false,
+        plugins: [
+            Chartist.plugins.fillDonut({
+                items: [{
+                    content: '<i class="fa fa-tachometer"></i>',
+                    position: 'bottom',
+                    offsetY : 10,
+                    offsetX: -2
+                }, {
+                    content: '<h3>160<span class="small">mph</span></h3>'
+                }]
+            })
+        ],
+    });
+
+chart.on('draw', function(data) {
+    if(data.type === 'slice' && data.index == 0) {
+        // Get the total path length in order to use for dash array animation
+        var pathLength = data.element._node.getTotalLength();
+
+        // Set a dasharray that matches the path length as prerequisite to animate dashoffset
+        data.element.attr({
+            'stroke-dasharray': pathLength + 'px ' + pathLength + 'px'
+        });
+
+        // Create animation definition while also assigning an ID to the animation for later sync usage
+        var animationDefinition = {
+            'stroke-dashoffset': {
+                id: 'anim' + data.index,
+                dur: 1200,
+                from: -pathLength + 'px',
+                to:  '0px',
+                easing: Chartist.Svg.Easing.easeOutQuint,
+                fill: 'freeze'
+            }
+        };
+
+        // We need to set an initial value before the animation starts as we are not in guided mode which would do that for us
+        data.element.attr({
+            'stroke-dashoffset': -pathLength + 'px'
+        });
+
+        // We can't use guided mode as the animations need to rely on setting begin manually
+        // See http://gionkunz.github.io/chartist-js/api-documentation.html#chartistsvg-function-animate
+        data.element.animate(animationDefinition, true);
+    }
+});

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -75,6 +75,7 @@
 <script src="bower_components/chartist-plugin-tooltip/dist/chartist-plugin-tooltip.js"></script>
 <script src="bower_components/chartist-plugin-axistitle/dist/chartist-plugin-axistitle.js"></script>
 <script src="bower_components/chartist-plugin-threshold/dist/chartist-plugin-threshold.js"></script>
+<script src="bower_components/chartist-plugin-fill-donut/dist/chartist-plugin-fill-donut.js"></script>
 
 <!-- Chartist site scripts -->
 <script src="scripts/main.js"></script>

--- a/site/styles/_example-charts.scss
+++ b/site/styles/_example-charts.scss
@@ -76,3 +76,35 @@
     fill: #59922b;
   }
 }
+
+#example-plugin-fill-donut {
+  .ct-chart-donut .ct-series-a .ct-slice-donut {
+    stroke: #d70206;
+  }
+
+  .ct-chart-donut .ct-series-b .ct-slice-donut {
+    stroke: rgba(0,0,0,.4);
+    opacity: 0.0;
+  }
+
+  .ct-chart-donut .ct-fill-donut .ct-slice-donut {
+    stroke: rgba(0,0,0,.4);
+    opacity: 1;
+  }
+
+  .ct-fill-donut-label {
+    h3 {
+      font-weight: bolder;
+    }
+    
+    small {
+      font-size: 0.6em;
+    }
+
+    
+    i { 
+      font-size: 1.5em; 
+    }
+
+  }
+}


### PR DESCRIPTION
a small plugin for animated donuts, it will draw the donut a second time and give him a background/fill look. Also provides the possibility to add multiple html/text labels on different positions.
