### PR TITLE
Small fix for stacked bars with 'holes' in the data

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -138,8 +138,8 @@
           return value;
         }).reduce(function(prev, curr) {
           return {
-            x: prev.x + curr.x || 0,
-            y: prev.y + curr.y || 0
+            x: prev.x + (curr && curr.x) || 0,
+            y: prev.y + (curr && curr.y) || 0
           };
         }, {x: 0, y: 0});
       });


### PR DESCRIPTION
Hi, 

I found a small issue that I couldn't get a stacked bar chart to render with 'holes' or undefined data in 2 series (but at the same position), I'd get a " Cannot read property 'x' of undefined" error. I'm not sure this fix covers all cases of holes in the data properly, but at least this fix worked for me, missing items are simply not rendered in the same way as for a non-stacked bar chart.
