### PR TITLE
fire beforeDraw event to allow adjustment of positionalData

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -789,6 +789,17 @@ var Chartist = {
     positionalData[axis.counterUnits.pos + '1'] = offset;
     positionalData[axis.counterUnits.pos + '2'] = offset + length;
 
+    // Event for grid beforeDraw
+    eventEmitter.emit('beforeDraw',
+      {
+        type: 'grid',
+        axis: axis,
+        index: index,
+        group: group,
+        positionalData: positionalData
+      }
+    );
+
     var gridElement = group.elem('line', positionalData, classes.join(' '));
 
     // Event for grid draw


### PR DESCRIPTION
This fires a beforeDraw event just before the grid gets drawn. 

This allows to change the positionalData to have grid lines that overlap the base lines on x and y axis e.g.

The positionalData object nees to be send with the event payload (without going through Chartist.extend) to not loose reference.

Not sure if this fits within the concept, but it is very useful for my usecase.

Let me know what you think and if I should change something.

example:

```
chart.on('beforeDraw', function(data) {
  if (data.type === 'grid') {
    if (data.axis.counterUnits.dir === "vertical") {
      data.positionalData.y1 = data.positionalData.y1 - 5;
      data.positionalData.y2 = data.positionalData.y2 + 5;
    } else if (data.axis.counterUnits.dir === "horizontal") {
      data.positionalData.x1 = data.positionalData.x1 - 5;
      data.positionalData.x2 = data.positionalData.x2 + 5;
    }
  }
}
```
