### PR TITLE
Fixed misspelling in overlapping bars example

### DIFF
--- a/site/examples/overlapping-bars.js
+++ b/site/examples/overlapping-bars.js
@@ -1,5 +1,5 @@
 var data = {
-  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
   series: [
     [5, 4, 3, 7, 5, 10, 3, 4, 8, 10, 6, 8],
     [3, 2, 9, 5, 4, 6, 4, 6, 7, 8, 7, 4]


### PR DESCRIPTION
The original overlapping bars example spelled the month of May as "Mai".
