### PR TITLE
Allow empty values to be ignored on pie charts

### DIFF
--- a/test/spec/spec-pie-chart.js
+++ b/test/spec/spec-pie-chart.js
@@ -217,6 +217,75 @@ describe('Pie chart tests', function() {
     });
 
   });
+  
+  describe('Pie with some empty values configured to be ignored', function() {
+    var data, options;
+
+    beforeEach(function() {
+      data = {
+        series: [1, 2, 0, 4]
+      };
+      options =  {
+        width: 100,
+        height: 100,
+        ignoreEmptyValues: true
+      };
+    });
+
+    function onCreated(callback) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+      var chart = new Chartist.Pie('.ct-chart', data, options);
+      chart.on('created', callback);
+    }
+
+    it('Pie should not render empty slices', function(done) {
+      onCreated(function() { 
+        var slices = $('.ct-slice-pie');
+        
+        expect(slices.length).toBe(3);
+        
+        expect(slices.eq(2).attr('ct:value')).toBe('1');
+        expect(slices.eq(1).attr('ct:value')).toBe('2');
+        expect(slices.eq(0).attr('ct:value')).toBe('4');
+        done();
+      });
+    });
+  });
+  
+  describe('Pie with some empty values configured not to be ignored', function() {
+    var data, options;
+
+    beforeEach(function() {
+      data = {
+        series: [1, 2, 0, 4]
+      };
+      options =  {
+        width: 100,
+        height: 100,
+        ignoreEmptyValues: false
+      };  
+    });
+
+    function onCreated(callback) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+      var chart = new Chartist.Pie('.ct-chart', data, options);
+      chart.on('created', callback);
+    }
+
+    it('Pie should render empty slices', function(done) {
+      onCreated(function() { 
+        var slices = $('.ct-slice-pie');
+        
+        expect(slices.length).toBe(4);
+        
+        expect(slices.eq(3).attr('ct:value')).toBe('1');
+        expect(slices.eq(2).attr('ct:value')).toBe('2');
+        expect(slices.eq(1).attr('ct:value')).toBe('0');
+        expect(slices.eq(0).attr('ct:value')).toBe('4');
+        done();
+      });
+    });
+  });
 
   describe('Gauge Chart', function() {
     // https://gionkunz.github.io/chartist-js/examples.html#gauge-chart


### PR DESCRIPTION
Ignoring empty values in pie charts avoids labels being drawn unnecessarily. This is useful as labels for empty slices can overlap other labels leading to a messy chart.

I've added a configuration option called 'ignoreEmptyValues' that defaults to backwards compatible situation (i.e. false). However, if you change this to 'true' then empty value slices will no longer be rendered (avoiding labelling problems).

Tests included.

May be possible to achieve this via custom labelInterpolationFnc option but couldn't see how so came up with this approach instead.

Other option of course is to avoid having the values in the data in the first place but in my particular use case this is problematic.

PS. This is my first pull request on GitHub so apologies in advance if not useful/appropriate. Thanks for a great charting library!
