### PR TITLE
Allow empty pie chart values to be ignored

### DIFF
--- a/src/scripts/charts/pie.js
+++ b/src/scripts/charts/pie.js
@@ -48,7 +48,9 @@
     // Label direction can be 'neutral', 'explode' or 'implode'. The labels anchor will be positioned based on those settings as well as the fact if the labels are on the right or left side of the center of the chart. Usually explode is useful when labels are positioned far away from the center.
     labelDirection: 'neutral',
     // If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
-    reverseData: false
+    reverseData: false,
+    // If true empty values will be ignored to avoid drawing unncessary slices and labels
+    ignoreEmptyValues: false
   };
 
   /**
@@ -143,6 +145,9 @@
     // Draw the series
     // initialize series groups
     for (var i = 0; i < this.data.series.length; i++) {
+      // If current value is zero and we are ignoring empty values then skip to next value
+      if (dataArray[i] === 0 && options.ignoreEmptyValues) continue;
+
       var series = this.data.series[i];
       seriesGroups[i] = this.svg.elem('g', null, null, true);
 

--- a/test/spec/spec-pie-chart.js
+++ b/test/spec/spec-pie-chart.js
@@ -217,6 +217,75 @@ describe('Pie chart tests', function() {
     });
 
   });
+  
+  describe('Pie with some empty values configured to be ignored', function() {
+    var data, options;
+
+    beforeEach(function() {
+      data = {
+        series: [1, 2, 0, 4]
+      };
+      options =  {
+        width: 100,
+        height: 100,
+        ignoreEmptyValues: true
+      };
+    });
+
+    function onCreated(callback) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+      var chart = new Chartist.Pie('.ct-chart', data, options);
+      chart.on('created', callback);
+    }
+
+    it('Pie should not render empty slices', function(done) {
+      onCreated(function() { 
+        var slices = $('.ct-slice-pie');
+        
+        expect(slices.length).toBe(3);
+        
+        expect(slices.eq(2).attr('ct:value')).toBe('1');
+        expect(slices.eq(1).attr('ct:value')).toBe('2');
+        expect(slices.eq(0).attr('ct:value')).toBe('4');
+        done();
+      });
+    });
+  });
+  
+  describe('Pie with some empty values configured not to be ignored', function() {
+    var data, options;
+
+    beforeEach(function() {
+      data = {
+        series: [1, 2, 0, 4]
+      };
+      options =  {
+        width: 100,
+        height: 100,
+        ignoreEmptyValues: false
+      };  
+    });
+
+    function onCreated(callback) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+      var chart = new Chartist.Pie('.ct-chart', data, options);
+      chart.on('created', callback);
+    }
+
+    it('Pie should render empty slices', function(done) {
+      onCreated(function() { 
+        var slices = $('.ct-slice-pie');
+        
+        expect(slices.length).toBe(4);
+        
+        expect(slices.eq(3).attr('ct:value')).toBe('1');
+        expect(slices.eq(2).attr('ct:value')).toBe('2');
+        expect(slices.eq(1).attr('ct:value')).toBe('0');
+        expect(slices.eq(0).attr('ct:value')).toBe('4');
+        done();
+      });
+    });
+  });
 
   describe('Gauge Chart', function() {
     // https://gionkunz.github.io/chartist-js/examples.html#gauge-chart


### PR DESCRIPTION
Empty pie chart values can render with overlapping labels. This adds a
configuration option to allow them to be ignored when rendering the pie
chart.

Tests included.

This replaces previous pull request which wrapped an IF block around most of the rendering code (resetting it one level deeper and making the PR unclear). This version avoids that in favour of a simple loop “continue” when empty value met and option set to ignore them.
