### PR TITLE
Polyfill for Function.prototype.bind

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -9,7 +9,29 @@ var Chartist = {
 
 (function (window, document, Chartist) {
   'use strict';
+  // Polyfill for Function.prototype.bind: https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+  if (!Function.prototype.bind) {
+    Function.prototype.bind = function(oThis) {
+      if (typeof this !== 'function') {
+        // closest thing possible to the ECMAScript 5
+        // internal IsCallable function
+        throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+      }
 
+      var aArgs   = Array.prototype.slice.call(arguments, 1),
+          fToBind = this,
+          fNOP    = function() {},
+          fBound  = function() {
+            return fToBind.apply(this instanceof fNOP ? this : oThis,
+                   aArgs.concat(Array.prototype.slice.call(arguments)));
+          };
+
+      fNOP.prototype = this.prototype;
+      fBound.prototype = new fNOP();
+
+      return fBound;
+    };
+  }
   /**
    * Helps to simplify functional style code
    *


### PR DESCRIPTION
PhantomJS 1.9.7 fails because Function.prototype.bind is not defined: https://github.com/ariya/phantomjs/issues/10522

The polyfill function should be good workaround for that: https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Function/bind

PhantomJS is nice for server-side rendering. HTML can be easily converted to a SVG file.
