### PR TITLE
Style hooks providing colors of series for user-built legend

### DIFF
--- a/src/styles/chartist.scss
+++ b/src/styles/chartist.scss
@@ -112,6 +112,10 @@
   }
 }
 
+@mixin ct-legend-series-color($color) {
+  color: $color;
+}
+
 @mixin ct-chart($ct-container-ratio: $ct-container-ratio, $ct-text-color: $ct-text-color, $ct-text-size: $ct-text-size, $ct-grid-color: $ct-grid-color, $ct-grid-width: $ct-grid-width, $ct-grid-dasharray: $ct-grid-dasharray, $ct-point-size: $ct-point-size, $ct-point-shape: $ct-point-shape, $ct-line-width: $ct-line-width, $ct-bar-width: $ct-bar-width, $ct-donut-width: $ct-donut-width, $ct-series-names: $ct-series-names, $ct-series-colors: $ct-series-colors) {
 
   .#{$ct-class-label} {
@@ -214,6 +218,12 @@
         $color: nth($ct-series-colors, $i + 1);
 
         @include ct-chart-series-color($color);
+      }
+      
+      .#{$ct-legend} .#{$ct-class-series}-#{nth($ct-series-names, $i + 1)} {
+        $color: nth($ct-series-colors, $i + 1);
+        
+        @include ct-legend-series-color($color);
       }
     }
   }

--- a/src/styles/chartist.scss
+++ b/src/styles/chartist.scss
@@ -220,7 +220,7 @@
         @include ct-chart-series-color($color);
       }
       
-      .#{$ct-legend} .#{$ct-class-series}-#{nth($ct-series-names, $i + 1)} {
+      .#{$ct-class-legend} .#{$ct-class-series}-#{nth($ct-series-names, $i + 1)} {
         $color: nth($ct-series-colors, $i + 1);
         
         @include ct-legend-series-color($color);

--- a/src/styles/chartist.scss
+++ b/src/styles/chartist.scss
@@ -219,7 +219,6 @@
 
         @include ct-chart-series-color($color);
       }
-      
       .#{$ct-class-legend} .#{$ct-class-series}-#{nth($ct-series-names, $i + 1)} {
         $color: nth($ct-series-colors, $i + 1);
         

--- a/src/styles/settings/_chartist-settings.scss
+++ b/src/styles/settings/_chartist-settings.scss
@@ -11,6 +11,7 @@ $ct-class-chart-pie: ct-chart-pie !default;
 $ct-class-chart-donut: ct-chart-donut !default;
 $ct-class-label: ct-label !default;
 $ct-class-series: ct-series !default;
+$ct-class-legend: ct-legend !default;
 $ct-class-line: ct-line !default;
 $ct-class-point: ct-point !default;
 $ct-class-area: ct-area !default;


### PR DESCRIPTION
In order for anyone to build a working legend out of the box (i.e. without customizing any scss), rules need to be surfaced that apply the proper "color: " rule. 

Possibly the .ct-legend class is overkill, but I wasn't sure about simply adding the color rule to the .ct-series-# classes.
