### PR TITLE
Implement stacked line charts

### DIFF
--- a/site/data/pages/examples.yml
+++ b/site/data/pages/examples.yml
@@ -11,6 +11,13 @@ sections:
           intro: An example of a simple line chart with three series. You can edit this example in realtime.
       - type: live-example
         data:
+          title: Stacked line chart
+          level: 4
+          id: stacked-line-chart
+          classes: ct-golden-section
+          intro: The same line chart, with each line's data accumulating from the previous line.
+      - type: live-example
+        data:
           title: Holes in data
           level: 4
           id: example-line-data-holes

--- a/site/examples/stacked-line-chart.js
+++ b/site/examples/stacked-line-chart.js
@@ -1,0 +1,14 @@
+new Chartist.Line('.ct-chart', {
+  labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+  series: [
+    [12, 9, 7, 8, 5],
+    [2, 1, 3.5, 7, 3],
+    [1, 3, 4, 5, 6]
+  ]
+}, {
+  fullWidth: true,
+  stackLines: true,
+  chartPadding: {
+    right: 40
+  }
+});

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -124,6 +124,27 @@
     var labelGroup = this.svg.elem('g').addClass(options.classNames.labelGroup);
 
     var chartRect = Chartist.createChartRect(this.svg, options, defaultOptions.padding);
+
+    // if the lines are supposed to be stacked, then stack the lines
+    // by adding the preceding values at each index to each data point.
+    // do this directly to the data here so the axes can react appropriately.
+    var stackedValues = [];
+    if (options.stackLines) {
+      data.normalized.forEach(function(series, seriesIndex) {
+        data.normalized[seriesIndex] = series.map(function(value, valueIndex) {
+          if (!value || !value.y) {
+            return value;
+          }
+          if (typeof stackedValues[valueIndex] === "undefined") {
+            stackedValues[valueIndex] = 0;
+          }
+          value.y += stackedValues[valueIndex];
+          stackedValues[valueIndex] += value.y;
+          return value;
+        });
+      }.bind(this));
+    }
+
     var axisX, axisY;
 
     if(options.axisX.type === undefined) {

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -195,6 +195,80 @@ describe('Line chart tests', function () {
       });
     });
 
+    it('should render correctly with Interpolation.simple, holes everywhere, and stacked lines', function (done) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+
+      var series = [
+        [5, 5, 10, 8, 7, 5, 4, null, null, null ],
+        [NaN, 15, 0, null, 2, 3, 4, undefined, {value: 1, meta: 'meta data'}, null],
+        [4, null, null, null, 10, 10, 7, 8, 6, 9]
+      ];
+      var chart = new Chartist.Line('.ct-chart', {
+        labels: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        series: series
+      }, {
+        stackLines: true,
+        lineSmooth: Chartist.Interpolation.simple()
+      });
+
+      var commandLines = [];
+      var expectedCommandLines = [
+        [
+          {"command":"M","data":{"value":{"y":5},"valueIndex":0}},
+          {"command":"C","data":{"value":{"y":5},"valueIndex":1}},
+          {"command":"C","data":{"value":{"y":10},"valueIndex":2}},
+          {"command":"C","data":{"value":{"y":8},"valueIndex":3}},
+          {"command":"C","data":{"value":{"y":7},"valueIndex":4}},
+          {"command":"C","data":{"value":{"y":5},"valueIndex":5}},
+          {"command":"C","data":{"value":{"y":4},"valueIndex":6}}
+        ],
+        [
+          {"command":"M","data":{"value":{"y":20},"valueIndex":1}},
+          {"command":"C","data":{"value":{"y":0},"valueIndex":2}},
+          {"command":"M","data":{"value":{"y":9},"valueIndex":4}},
+          {"command":"C","data":{"value":{"y":8},"valueIndex":5}},
+          {"command":"C","data":{"value":{"y":8},"valueIndex":6}},
+          {"command":"M","data":{"value":{"y":1},"valueIndex":8,"meta":"meta data"}}
+        ],
+        [
+          {"command":"M","data":{"value":{"y":9},"valueIndex":0}},
+          {"command":"M","data":{"value":{"y":26},"valueIndex":4}},
+          {"command":"C","data":{"value":{"y":23},"valueIndex":5}},
+          {"command":"C","data":{"value":{"y":19},"valueIndex":6}},
+          {"command":"C","data":{"value":{"y":8},"valueIndex":7}},
+          {"command":"C","data":{"value":{"y":7},"valueIndex":8}},
+          {"command":"C","data":{"value":{"y":9},"valueIndex":9}}
+        ]
+      ];
+
+      var onDraw = function (context) {
+        var commands;
+        if (context.type === 'line') {
+          commands = context.path.pathElements.map(function (pathElement) {
+            return {
+              command: pathElement.command,
+              data: pathElement.data
+            };
+          });
+          commandLines.push(commands);
+
+          // wait until three lines are drawn
+          if (commandLines.length === series.length) {
+            // jasmine has a really hard time comparing these two arrays,
+            // even if we loop through each level individually.
+            // so cheat and compare the stringified versions.
+            expect(JSON.stringify(commandLines)).
+              toEqual(JSON.stringify(expectedCommandLines));
+
+            chart.off('draw', onDraw);
+            done();
+          }
+        }
+      }
+
+      chart.on('draw', onDraw);
+    });
+
     it('should render correctly with postponed Interpolation.step and holes everywhere', function (done) {
       jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
 


### PR DESCRIPTION
I noticed that Chartist allows stacked bar charts, but not line charts. So I added this feature for line charts, along with an example and test.

The implementation is a little blunt: during the render step, I modify the data object directly before all the other actions happen. I need to do this to get the axes do adapt to the data changes. I hope this is okay.

As always, feedback is appreciated!

:thumbsup:
