### PR TITLE
Fix for 464: include zero in ct:value

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -346,9 +346,7 @@
 
         // Create bar element
         bar = seriesElement.elem('line', positions, options.classNames.bar).attr({
-          'value': [value.x, value.y].filter(function(v) {
-            return v || v === 0;
-          }).join(','),
+          'value': [value.x, value.y].filter(Chartist.isNum).join(','),
           'meta': Chartist.getMetaData(series, valueIndex)
         }, Chartist.xmlNs.uri);
 

--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -347,7 +347,7 @@
         // Create bar element
         bar = seriesElement.elem('line', positions, options.classNames.bar).attr({
           'value': [value.x, value.y].filter(function(v) {
-            return v;
+            return v || v === 0;
           }).join(','),
           'meta': Chartist.getMetaData(series, valueIndex)
         }, Chartist.xmlNs.uri);

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -206,7 +206,7 @@
             y2: pathElement.y
           }, options.classNames.point).attr({
             'value': [pathElement.data.value.x, pathElement.data.value.y].filter(function(v) {
-                return v;
+                return v || v === 0;
               }).join(','),
             'meta': pathElement.data.meta
           }, Chartist.xmlNs.uri);

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -205,9 +205,7 @@
             x2: pathElement.x + 0.01,
             y2: pathElement.y
           }, options.classNames.point).attr({
-            'value': [pathElement.data.value.x, pathElement.data.value.y].filter(function(v) {
-                return v || v === 0;
-              }).join(','),
+            'value': [pathElement.data.value.x, pathElement.data.value.y].filter(Chartist.isNum).join(','),
             'meta': pathElement.data.meta
           }, Chartist.xmlNs.uri);
 

--- a/test/spec/spec-bar-chart.js
+++ b/test/spec/spec-bar-chart.js
@@ -9,6 +9,52 @@ describe('Bar chart tests', function() {
 
   });
 
+  describe('ct:value attribute', function() {
+    it('should contain x and y value for each bar', function(done) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+
+      var chart = new Chartist.Bar('.ct-chart', {
+        series: [[
+          {x: 1, y: 2},
+          {x: 3, y: 4}
+        ]]
+      }, {
+        axisX: {
+          type: Chartist.AutoScaleAxis
+        }
+      });
+
+      chart.on('created', function() {
+        expect($('.ct-bar').eq(0).attr('ct:value')).toEqual('1,2');
+        expect($('.ct-bar').eq(1).attr('ct:value')).toEqual('3,4');
+        done();
+      });
+    });
+
+    it('should render values that are zero', function(done) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+
+      var chart = new Chartist.Bar('.ct-chart', {
+        series: [[
+          {x: 0, y: 1},
+          {x: 2, y: 0},
+          {x: 0, y: 0}
+        ]]
+      }, {
+        axisX: {
+          type: Chartist.AutoScaleAxis
+        }
+      });
+
+      chart.on('created', function() {
+        expect($('.ct-bar').eq(0).attr('ct:value')).toEqual('0,1');
+        expect($('.ct-bar').eq(1).attr('ct:value')).toEqual('2,0');
+        expect($('.ct-bar').eq(2).attr('ct:value')).toEqual('0,0');
+        done();
+      });
+    });
+  });
+
   describe('Meta data tests', function () {
     it('should render meta data correctly with mixed value array', function(done) {
       jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -9,6 +9,52 @@ describe('Line chart tests', function () {
 
   });
 
+  describe('ct:value attribute', function () {
+    it('should contain x and y value for each datapoint', function (done) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+
+      var chart = new Chartist.Line('.ct-chart', {
+        series: [[
+          {x: 1, y: 2},
+          {x: 3, y: 4}
+        ]]
+      }, {
+        axisX: {
+          type: Chartist.FixedScaleAxis
+        }
+      });
+
+      chart.on('created', function () {
+        expect($('.ct-point').eq(0).attr('ct:value')).toEqual('1,2');
+        expect($('.ct-point').eq(1).attr('ct:value')).toEqual('3,4');
+        done();
+      });
+    });
+
+    it('should render values that are zero', function (done) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+
+      var chart = new Chartist.Line('.ct-chart', {
+        series: [[
+          {x: 0, y: 1},
+          {x: 1, y: 0},
+          {x: 0, y: 0}
+        ]]
+      }, {
+        axisX: {
+          type: Chartist.FixedScaleAxis
+        }
+      });
+
+      chart.on('created', function () {
+        expect($('.ct-point').eq(0).attr('ct:value')).toEqual('0,1');
+        expect($('.ct-point').eq(1).attr('ct:value')).toEqual('1,0');
+        expect($('.ct-point').eq(2).attr('ct:value')).toEqual('0,0');
+        done();
+      });
+    });
+  });
+
   describe('Meta data tests', function () {
     it('should render meta data correctly with mixed value array', function (done) {
       jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -25,8 +25,8 @@ describe('Line chart tests', function () {
       });
 
       chart.on('created', function () {
-        expect($('.ct-point').eq(0).attr('ct:value')).toEqual('1,2');
-        expect($('.ct-point').eq(1).attr('ct:value')).toEqual('3,4');
+        expect($('.ct-point').eq(0).attr('ct:value')).toBe('1,2');
+        expect($('.ct-point').eq(1).attr('ct:value')).toBe('3,4');
         done();
       });
     });
@@ -47,9 +47,9 @@ describe('Line chart tests', function () {
       });
 
       chart.on('created', function () {
-        expect($('.ct-point').eq(0).attr('ct:value')).toEqual('0,1');
-        expect($('.ct-point').eq(1).attr('ct:value')).toEqual('1,0');
-        expect($('.ct-point').eq(2).attr('ct:value')).toEqual('0,0');
+        expect($('.ct-point').eq(0).attr('ct:value')).toBe('0,1');
+        expect($('.ct-point').eq(1).attr('ct:value')).toBe('1,0');
+        expect($('.ct-point').eq(2).attr('ct:value')).toBe('0,0');
         done();
       });
     });


### PR DESCRIPTION
Changes
- `ct:value` attribute of `line.ct-point` in Line charts no longer omits 0 values
- `ct:value` attribute of `line.ct-bar` in Bar charts no longer omits 0 values

I'm not completely sure if this change is appropriate for Bar chart but it seemed like it. I can remove that from PR if it should not be in there.

Fixes #464 
