### PR TITLE
Fixed bug with negative start angle getting set to 0 for donut charts

### DIFF
--- a/dist/chartist.js
+++ b/dist/chartist.js
@@ -3971,7 +3971,7 @@ var Chartist = {
       var endAngle = startAngle + dataArray[i] / totalDataSum * 360;
 
       // Use slight offset so there are no transparent hairline issues
-      var overlappigStartAngle = Math.max(0, startAngle - (i === 0 || hasSingleValInSeries ? 0 : 0.2));
+      var overlappigStartAngle = Math.max(-360, startAngle - (i === 0 || hasSingleValInSeries ? 0 : 0.2));
 
       // If we need to draw the arc for all 360 degrees we need to add a hack where we close the circle
       // with Z and use 359.99 degrees


### PR DESCRIPTION
Bug introduced in commit ec00b726030a8b5ec90b263a0cca7a65dc98b4f3

e.g. If I pass a start angle of -150, this is getting set to 0 by the Math.max() function.
