### PR TITLE
Prevent negative value for foreignObject width attribute

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -882,7 +882,7 @@ var Chartist = {
     positionalData[axis.units.pos] = position + labelOffset[axis.units.pos];
     positionalData[axis.counterUnits.pos] = labelOffset[axis.counterUnits.pos];
     positionalData[axis.units.len] = length;
-    positionalData[axis.counterUnits.len] = axisOffset - 10;
+    positionalData[axis.counterUnits.len] = Math.max(0, axisOffset - 10);
 
     if(useForeignObject) {
       // We need to set width and height explicitly to px as span will not expand with width and height being


### PR DESCRIPTION
When I create a line chart with a custom offset like this:

``` js
Chartist.Line(Node, {labels, series}, {
  axisY: {
    offset: 0
  }
})
```

I'm getting this error:

![image](https://cloud.githubusercontent.com/assets/1263865/13423515/a45b846e-df9b-11e5-8ab0-e5c4fb1a8249.png)

I can't figure it out why this `- 10` [in this line](https://github.com/gionkunz/chartist-js/blob/develop/src/scripts/core.js#L885) is necessary, but looks like it is some hard coded value, and removing it resolves problem.

I'm presume this will cause a visual change for the apps which are currently using the lib. Anyway, I've readed the contributing file, but let me know if this PR is ok
