### PR TITLE
Zoom plugin 0.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "chartist-plugin-axistitle": "~0.0.1",
     "chartist-plugin-threshold": "~0.0.1",
     "chartist-plugin-fill-donut": "~0.0.1",
-    "chartist-plugin-zoom": "~0.0.1",
+    "chartist-plugin-zoom": "~0.2.1",
     "matchMedia": "~0.2.0"
   },
   "ignore": [


### PR DESCRIPTION
Fixes gionkunz/chartist-js#535.
Update zoom plugin example to use 0.2.1 which has several fixes. Example now works in Firefox.
