### PR TITLE
Fix #642 Update grunt-sass to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-critical": "0.1.1",
     "grunt-newer": "^1.1.0",
-    "grunt-sass": "^0.18.0",
+    "grunt-sass": "^1.1.0",
     "grunt-svgmin": "~2.0.0",
     "grunt-template": "^0.2.3",
     "grunt-umd": "~2.3.1",


### PR DESCRIPTION
Fix #642 
grunt-sass 0.18.0 does not work with newer node versions.
