### PR TITLE
Added 'license' property to package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "style": "dist/chartist.min.css",
   "main": "dist/chartist.js",
   "browser": "dist/chartist.js",
+  "license": "MIT OR WTFPL",
   "licenses": [
     {
       "type": "WTFPL",


### PR DESCRIPTION
When users install chartist currently there is a warning: `npm WARN chartist@0.9.7 No license field.`. This PR corrects that by adding a corresponding `license` field to the `package.json` file, which has a SPDX expression to represent the dual MIT / WTFPL licensing.
Also note that the use of the `licenses` property in `package.json` is deprecated (see https://github.com/npm/npm/issues/4473 and https://github.com/npm/npm/issues/7091), but I didn't remove it from the `package.json` in the spirit of not changing more than is necessary.
