### PR TITLE
Avoid blurred grid lines

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -747,7 +747,9 @@ var Chartist = {
     var values = [];
     for (i = bounds.min; i <= bounds.max; i += bounds.step) {      
       var value = Chartist.roundWithPrecision(i);      
-      value != values[values.length - 1] && values.push(i);
+      if (value !== values[values.length - 1]) {
+        values.push(i);
+      }
     }
     bounds.values = values;
     return bounds;

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -845,6 +845,7 @@ var Chartist = {
    */
   Chartist.createGrid = function(position, index, axis, offset, length, group, classes, eventEmitter) {
     var positionalData = {};
+    position = Math.round(position) + 0.5;  // Avoid blurred lines
     positionalData[axis.units.pos + '1'] = position;
     positionalData[axis.units.pos + '2'] = position;
     positionalData[axis.counterUnits.pos + '1'] = offset;

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
         '<%= pkg.config.src %>/scripts/charts/pie.js'
       ],
       options: {
+        summary: true,
         specs: '<%= pkg.config.test %>/spec/**/spec-*.js',
         helpers: '<%= pkg.config.test %>/spec/**/helper-*.js',
         vendor: [          

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -427,13 +427,13 @@ describe('Chartist core', function() {
     }
     
     it('should add single grid line to group', function(done) {
-      onCreated(function(grid) {
+      onCreated(function() {
         expect(group.querySelectorAll('line').svgElements.length).toBe(1);
       }, done);            
     }); 
     
     it('should add half pixel offset to position to avoid blurry lines', function(done) {
-      onCreated(function(grid) {
+      onCreated(function() {
         var line = group.querySelector('line'); 
         expect(line.attr('x1')).toBe('10.5');
         expect(line.attr('x2')).toBe('10.5');
@@ -445,7 +445,7 @@ describe('Chartist core', function() {
     it('should draw horizontal line', function(done) {
       axis.units.pos = 'y';
       axis.counterUnits.pos = 'x';
-      onCreated(function(grid) {
+      onCreated(function() {
         var line = group.querySelector('line'); 
         expect(line.attr('y1')).toBe('10.5');
         expect(line.attr('y2')).toBe('10.5');

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -398,7 +398,7 @@ describe('Chartist core', function() {
   });
   
   
-  fdescribe('createGrid', function() {
+  describe('createGrid', function() {
     var group, axis, classes, eventEmitter, position, length, offset;
     
     beforeEach(function() {

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -398,4 +398,61 @@ describe('Chartist core', function() {
   });
   
   
+  fdescribe('createGrid', function() {
+    var group, axis, classes, eventEmitter, position, length, offset;
+    
+    beforeEach(function() {
+      eventEmitter = Chartist.EventEmitter();
+      group = new Chartist.Svg('g');
+      axis = {
+        units: {
+          pos : 'x'
+        },
+        counterUnits: {
+          pos : 'y'
+        }
+      }; 
+      classes = [];
+      position = 10;
+      length = 100;
+      offset = 20;
+    });
+    
+    function onCreated(fn, done) {
+      eventEmitter.addEventHandler('draw', function(grid) {
+        fn(grid);
+        done();
+      });
+      Chartist.createGrid(position, 1, axis, offset, length, group, classes, eventEmitter);
+    }
+    
+    it('should add single grid line to group', function(done) {
+      onCreated(function(grid) {
+        expect(group.querySelectorAll('line').svgElements.length).toBe(1);
+      }, done);            
+    }); 
+    
+    it('should add half pixel offset to position to avoid blurry lines', function(done) {
+      onCreated(function(grid) {
+        var line = group.querySelector('line'); 
+        expect(line.attr('x1')).toBe('10.5');
+        expect(line.attr('x2')).toBe('10.5');
+        expect(line.attr('y1')).toBe('20');
+        expect(line.attr('y2')).toBe('120');
+      }, done);            
+    }); 
+    
+    it('should draw horizontal line', function(done) {
+      axis.units.pos = 'y';
+      axis.counterUnits.pos = 'x';
+      onCreated(function(grid) {
+        var line = group.querySelector('line'); 
+        expect(line.attr('y1')).toBe('10.5');
+        expect(line.attr('y2')).toBe('10.5');
+        expect(line.attr('x1')).toBe('20');
+        expect(line.attr('x2')).toBe('120');
+      }, done);            
+    }); 
+
+  });
 });


### PR DESCRIPTION
For issue https://github.com/gionkunz/chartist-js/issues/650
Looks good on Chrome. Doesn't seem to help for Firefox and IE. Not testes on Safari...
