### PR TITLE
Jolla browser compatibility

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -786,8 +786,8 @@ var Chartist = {
     var yAxisOffset = hasAxis ? options.axisY.offset : 0;
     var xAxisOffset = hasAxis ? options.axisX.offset : 0;
     // If width or height results in invalid value (including 0) we fallback to the unitless settings or even 0
-    var width = svg.width() || Chartist.quantity(options.width).value || 0;
-    var height = svg.height() || Chartist.quantity(options.height).value || 0;
+    var width = svg.width() || Chartist.quantity(options.width).value || parseInt(window.getComputedStyle(svg._node).width, 10) || 0;
+    var height = svg.height() || Chartist.quantity(options.height).value || parseInt(window.getComputedStyle(svg._node).height, 10) || 0;
     var normalizedPadding = Chartist.normalizePadding(options.chartPadding, fallbackPadding);
 
     // If settings were to small to cope with offset (legacy) and padding, we'll adjust


### PR DESCRIPTION
getBoundingClientRect returns 0 height and width on the [Jolla](https://jolla.com/) [browser](https://github.com/sailfishos/sailfish-browser), which causes charts that don't have dimensions set in the options to end up drawn entirely in the top left corner. Presumably this is due to [Mozilla bug 530985](https://bugzilla.mozilla.org/show_bug.cgi?id=530985). It can be worked around by using `window.getComputedStyle` to get the dimensions of the svg element.
