### PR TITLE
Chartist.extend performance

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -56,18 +56,20 @@ var Chartist = {
    * @return {Object} An object that has the same reference as target but is extended and merged with the properties of source
    */
   Chartist.extend = function (target) {
+    var i, source, sourceProp;
     target = target || {};
 
-    var sources = Array.prototype.slice.call(arguments, 1);
-    sources.forEach(function(source) {
+    for (i = 1; i < arguments.length; i++) {
+      source = arguments[i];
       for (var prop in source) {
-        if (typeof source[prop] === 'object' && source[prop] !== null && !(source[prop] instanceof Array)) {
-          target[prop] = Chartist.extend({}, target[prop], source[prop]);
+        sourceProp = source[prop];
+        if (typeof sourceProp === 'object' && sourceProp !== null && !(sourceProp instanceof Array)) {
+          target[prop] = Chartist.extend(target[prop], sourceProp);
         } else {
-          target[prop] = source[prop];
+          target[prop] = sourceProp;
         }
       }
-    });
+    };
 
     return target;
   };


### PR DESCRIPTION
While writing a page that draws some charts with over 1k points each, I noticed that Chartist.extend was taking up a lot of time, so I optimized it.

I have attached a simple test page that logs the time to draw one chart with 2k points. On my machine I get results like this (milliseconds, averaged over three trials):

```
            Original    Optimized
Firefox 45       229          140
Chrome 49        122           91
IE 11            380          166
```

[test.zip](https://github.com/gionkunz/chartist-js/files/217762/test.zip)
