### PR TITLE
Prototype.js compatibility

### DIFF
--- a/dist/chartist.js
+++ b/dist/chartist.js
@@ -1993,13 +1993,10 @@ var Chartist = {
    * @return {Chartist.Svg} The wrapper of the current element
    */
   function addClass(names) {
-    this._node.setAttribute('class',
-      this.classes(this._node)
-        .concat(names.trim().split(/\s+/))
-        .filter(function(elem, pos, self) {
-          return self.indexOf(elem) === pos;
-        }).join(' ')
-    );
+  	var arr = this.classes(this._node).concat(names.trim().split(/\s+/));
+  	this._node.setAttribute('class', arr.filter(function(elem, pos) {
+	  	return arr.indexOf(elem) === pos;
+	  }).join(' '));
 
     return this;
   }


### PR DESCRIPTION
For some reason, Prototype.js removes the ability for .filter() to use the third argument to refer back to the object it is modifying, used here as "self".

Yes, this is entirely the fault of Prototype.js; this shim simply allows Chartist to operate in this broken environment.

I submit this with the hope, merged or not, it prevents at least one person tearing their hair out when having to find out what the heck was going on.

Huge love for Chartist, by the way. What a wonderful library!
