### PR TITLE
Added option to ensure target tick value in AutoScaleAxis

### DIFF
--- a/src/scripts/axes/auto-scale-axis.js
+++ b/src/scripts/axes/auto-scale-axis.js
@@ -14,6 +14,8 @@
  *   onlyInteger: true,
  *   // The reference value can be used to make sure that this value will always be on the chart. This is especially useful on bipolar charts where the bipolar center always needs to be part of the chart.
  *   referenceValue: 5
+ *   // If the tick value is set, its number is going to be included in the axis' ticks
+ *   ensureTickValue: 0
  * };
  * ```
  *
@@ -26,7 +28,7 @@
   function AutoScaleAxis(axisUnit, data, chartRect, options) {
     // Usually we calculate highLow based on the data but this can be overriden by a highLow object in the options
     var highLow = options.highLow || Chartist.getHighLow(data.normalized, options, axisUnit.pos);
-    this.bounds = Chartist.getBounds(chartRect[axisUnit.rectEnd] - chartRect[axisUnit.rectStart], highLow, options.scaleMinSpace || 20, options.onlyInteger);
+    this.bounds = Chartist.getBounds(chartRect[axisUnit.rectEnd] - chartRect[axisUnit.rectStart], highLow, options.scaleMinSpace || 20, options.onlyInteger, options.ensureTickValue);
     this.range = {
       min: this.bounds.min,
       max: this.bounds.max

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -732,7 +732,7 @@ var Chartist = {
     bounds.step = Math.max(bounds.step, EPSILON);
 
     var values = [], value;
-    if (ensureTickValue || ensureTickValue === 0) {
+    if (typeof ensureTickValue === 'number') {
 
       // Avoid min to be higher and max to be lower than the ensured tick value
       bounds.min = Math.min(bounds.min, ensureTickValue);

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -674,7 +674,7 @@ var Chartist = {
    * @param {Boolean} onlyInteger
    * @return {Object} All the values to set the bounds of the chart
    */
-  Chartist.getBounds = function (axisLength, highLow, scaleMinSpace, onlyInteger) {
+  Chartist.getBounds = function (axisLength, highLow, scaleMinSpace, onlyInteger, ensureTickValue) {
     var i,
       optimizationCounter = 0,
       newMin,
@@ -730,26 +730,50 @@ var Chartist = {
     // step must not be less than EPSILON to create values that can be represented as floating number.
     var EPSILON = 2.221E-16;
     bounds.step = Math.max(bounds.step, EPSILON);
-    
-    // Narrow min and max based on new step
-    newMin = bounds.min;
-    newMax = bounds.max;
-    while(newMin + bounds.step <= bounds.low) {
-      newMin += bounds.step;
-    }
-    while(newMax - bounds.step >= bounds.high) {
-      newMax -= bounds.step;
-    }
-    bounds.min = newMin;
-    bounds.max = newMax;
-    bounds.range = bounds.max - bounds.min;
 
-    var values = [];
-    for (i = bounds.min; i <= bounds.max; i += bounds.step) {      
-      var value = Chartist.roundWithPrecision(i);      
-      value != values[values.length - 1] && values.push(i);
+    var values = [], value;
+    if (ensureTickValue || ensureTickValue === 0) {
+
+      // Avoid min to be higher and max to be lower than the ensured tick value
+      bounds.min = Math.min(bounds.min, ensureTickValue);
+      bounds.max = Math.max(bounds.max, ensureTickValue);
+
+      // Step up and down from the ensured value to generate tick values, min value and max value
+      value = ensureTickValue;
+      while (value > bounds.min) {
+        values.push(Chartist.roundWithPrecision((value -= bounds.step)));
+      }
+      bounds.min = value;
+      values = values.reverse();
+      values.push(value = ensureTickValue);
+      while (value < bounds.max) {
+        values.push(Chartist.roundWithPrecision((value += bounds.step)));
+      }
+      bounds.max = value;
+
+    } else {
+
+      // Narrow min and max based on new step
+      newMin = bounds.min;
+      newMax = bounds.max;
+      while(newMin + bounds.step <= bounds.low) {
+        newMin += bounds.step;
+      }
+      while(newMax - bounds.step >= bounds.high) {
+        newMax -= bounds.step;
+      }
+      bounds.min = newMin;
+      bounds.max = newMax;
+
+      for (i = bounds.min; i <= bounds.max; i += bounds.step) {
+        value = Chartist.roundWithPrecision(i);
+        value != values[values.length - 1] && values.push(i);
+      }
+
     }
+
     bounds.values = values;
+    bounds.range = bounds.max - bounds.min;
     return bounds;
   };
 

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -420,6 +420,12 @@ describe('Chartist core', function() {
       expect(bounds.values).toEqual([-2,0,2,4,6,8,10,12,14,16]);
     });
 
+    it('should return values width floating numbers', function() {
+      var bounds = Chartist.getBounds(100, { high: 8.2, low: -1 }, 3, false, 0);
+      expect(bounds.step).toEqual(0.5);
+      expect(bounds.values).toEqual([-1, -0.5, 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9]);
+    });
+
 
   });
 

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -420,13 +420,18 @@ describe('Chartist core', function() {
       expect(bounds.values).toEqual([-2,0,2,4,6,8,10,12,14,16]);
     });
 
-    it('should return values width floating numbers', function() {
+    it('should return values with floating numbers', function() {
       var bounds = Chartist.getBounds(100, { high: 8.2, low: -1 }, 3, false, 0);
       expect(bounds.step).toEqual(0.5);
       expect(bounds.values).toEqual([-1, -0.5, 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9]);
     });
 
-
+    it('should respect floating numbers too', function() {
+      var bounds = Chartist.getBounds(100, { high: 8.2, low: -1 }, 15, false, 1.25);
+      expect(bounds.step).toEqual(2);
+      expect(bounds.values).toEqual([-2.75, -0.75, 1.25, 3.25, 5.25, 7.25, 9.25]);
+    });
+    
   });
 
   describe('splitIntoSegments', function() {

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -394,7 +394,33 @@ describe('Chartist core', function() {
       expect(bounds.high).toBe(1.0000000000000002);
       expect(bounds.values).toEqual([1]);
     });
-    
+
+    it('should return values with no zero included', function() {
+      var bounds = Chartist.getBounds(100, { high: 8.2, low: -1 }, 15, false);
+      expect(bounds.step).toEqual(2);
+      expect(bounds.values).toEqual([-1,1,3,5,7,9]);
+    });
+
+    it('should return values with zero included', function() {
+      var bounds = Chartist.getBounds(100, { high: 8.2, low: -1 }, 15, false, 0);
+      expect(bounds.step).toEqual(2);
+      expect(bounds.range).toEqual(12);
+      expect(bounds.values).toEqual([-2,0,2,4,6,8,10]);
+    });
+
+    it('should return values with -3 included', function() {
+      var bounds = Chartist.getBounds(100, { high: 8.2, low: -1 }, 15, false, -3);
+      expect(bounds.step).toEqual(2);
+      expect(bounds.values).toEqual([-3,-1,1,3,5,7,9]);
+    });
+
+    it('should return values with 16 included', function() {
+      var bounds = Chartist.getBounds(100, { high: 8.2, low: -1 }, 15, false, 16);
+      expect(bounds.step).toEqual(2);
+      expect(bounds.values).toEqual([-2,0,2,4,6,8,10,12,14,16]);
+    });
+
+
   });
 
   describe('splitIntoSegments', function() {


### PR DESCRIPTION
Sometimes you'd like to have a certain number included in the calculated ticks of a AutoScaleAxis. A popular use case for this is the zero axis grid line which is going to disappear if the scale – because of its given data – renders ticks like `[-3,-1,1,3]`. 
To ensure the include of zero the new introduced axis option will help: `ensureTickValue: 0` . Once defined, the values of the bounds are going to be re-set by stepping up and down from the target value (`0` in this case) while the already calculated step size is preserved. 
