### PR TITLE
Fix infinite loop in getBounds with a more robust increment.

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -727,25 +727,31 @@ var Chartist = {
       }
     }
 
-    // step must not be less than EPSILON to create values that can be represented as floating number.
     var EPSILON = 2.221E-16;
     bounds.step = Math.max(bounds.step, EPSILON);
+    function safeIncrement(value, increment) {
+      // If increment is too small use *= (1+EPSILON) as a simple nextafter
+      if (value === (value += increment)) {
+      	value *= (1 + (increment > 0 ? EPSILON : -EPSILON));
+      }
+      return value;
+    }
 
     // Narrow min and max based on new step
     newMin = bounds.min;
     newMax = bounds.max;
-    while(newMin + bounds.step <= bounds.low) {
-      newMin += bounds.step;
+    while (newMin + bounds.step <= bounds.low) {
+    	newMin = safeIncrement(newMin, bounds.step);
     }
-    while(newMax - bounds.step >= bounds.high) {
-      newMax -= bounds.step;
+    while (newMax - bounds.step >= bounds.high) {
+    	newMax = safeIncrement(newMax, -bounds.step);
     }
     bounds.min = newMin;
     bounds.max = newMax;
     bounds.range = bounds.max - bounds.min;
 
     var values = [];
-    for (i = bounds.min; i <= bounds.max; i += bounds.step) {
+    for (i = bounds.min; i <= bounds.max; i = safeIncrement(i, bounds.step)) {
       var value = Chartist.roundWithPrecision(i);
       if (value !== values[values.length - 1]) {
         values.push(i);

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -395,6 +395,15 @@ describe('Chartist core', function() {
       expect(bounds.values).toEqual([1]);
     });
     
+    it('should return single step if range is less than smallest increment', function() {
+      var bounds = Chartist.getBounds(613.234375, { high: 1000.0000000000001, low: 999.9999999999997 }, 50, false);
+      expect(bounds.min).toBe(999.9999999999999);
+      expect(bounds.max).toBe(1000);
+      expect(bounds.low).toBe(999.9999999999997);
+      expect(bounds.high).toBe(1000.0000000000001);
+      expect(bounds.values).toEqual([999.9999999999999]);
+    });
+
   });
 
   describe('splitIntoSegments', function() {


### PR DESCRIPTION
This is related to bfdc8f2 which introduced EPSILON as the smallest increment but fails for bigger numbers.
See https://github.com/gionkunz/chartist-js/pull/645

This fix uses `value *= (1 + EPSILON)` instead of `value += EPSILON` to prevent inifinite loops in `getBounds`. EPSILON is only safe when incrementing 1.
