### PR TITLE
Use two different containers for horizontal and vertical lines

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -94,7 +94,8 @@
       chart: 'ct-chart-bar',
       horizontalBars: 'ct-horizontal-bars',
       label: 'ct-label',
-      labelGroup: 'ct-labels',
+      labelGroupVertical: 'ct-labels-vertical',
+      labelGroupHorizontal: 'ct-labels-horizontal',
       series: 'ct-series',
       bar: 'ct-bar',
       grid: 'ct-grid',
@@ -137,7 +138,8 @@
     var gridGroupVertical = this.svg.elem('g').addClass(options.classNames.gridGroupVertical);
     var gridGroupHorizontal = this.svg.elem('g').addClass(options.classNames.gridGroupHorizontal);
     var seriesGroup = this.svg.elem('g');
-    var labelGroup = this.svg.elem('g').addClass(options.classNames.labelGroup);
+    var labelGroupVertical = this.svg.elem('g').addClass(options.classNames.labelGroupVertical);
+    var labelGroupHorizontal = this.svg.elem('g').addClass(options.classNames.labelGroupHorizontal);
 
     if(options.stackBars && data.normalized.series.length !== 0) {
 
@@ -232,8 +234,8 @@
     // Used to track the screen coordinates of stacked bars
     var stackedBarValues = [];
 
-    labelAxis.createGridAndLabels(gridGroupHorizontal, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
-    valueAxis.createGridAndLabels(gridGroupVertical, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
+    labelAxis.createGridAndLabels(gridGroupHorizontal, labelGroupHorizontal, this.supportsForeignObject, options, this.eventEmitter);
+    valueAxis.createGridAndLabels(gridGroupVertical, labelGroupVertical, this.supportsForeignObject, options, this.eventEmitter);
 
     if (options.showGridBackground) {
       Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);

--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -98,7 +98,8 @@
       series: 'ct-series',
       bar: 'ct-bar',
       grid: 'ct-grid',
-      gridGroup: 'ct-grids',
+      gridGroupVertical: 'ct-grids-vertical',
+      gridGroupHorizontal: 'ct-grids-horizontal',
       gridBackground: 'ct-grid-background',
       vertical: 'ct-vertical',
       horizontal: 'ct-horizontal',
@@ -133,7 +134,8 @@
     );
 
     // Drawing groups in correct order
-    var gridGroup = this.svg.elem('g').addClass(options.classNames.gridGroup);
+    var gridGroupVertical = this.svg.elem('g').addClass(options.classNames.gridGroupVertical);
+    var gridGroupHorizontal = this.svg.elem('g').addClass(options.classNames.gridGroupHorizontal);
     var seriesGroup = this.svg.elem('g');
     var labelGroup = this.svg.elem('g').addClass(options.classNames.labelGroup);
 
@@ -230,8 +232,8 @@
     // Used to track the screen coordinates of stacked bars
     var stackedBarValues = [];
 
-    labelAxis.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
-    valueAxis.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
+    labelAxis.createGridAndLabels(gridGroupHorizontal, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
+    valueAxis.createGridAndLabels(gridGroupVertical, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
 
     if (options.showGridBackground) {
       Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);

--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -238,7 +238,7 @@
     valueAxis.createGridAndLabels(gridGroupVertical, labelGroupVertical, this.supportsForeignObject, options, this.eventEmitter);
 
     if (options.showGridBackground) {
-      Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);
+      Chartist.createGridBackground(gridGroupHorizontal, chartRect, options.classNames.gridBackground, this.eventEmitter);
     }
 
     // Draw the series

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -100,7 +100,8 @@
       point: 'ct-point',
       area: 'ct-area',
       grid: 'ct-grid',
-      gridGroup: 'ct-grids',
+      gridGroupVertical: 'ct-grids-vertical',
+      gridGroupHorizontal: 'ct-grids-horizontal',
       gridBackground: 'ct-grid-background',
       vertical: 'ct-vertical',
       horizontal: 'ct-horizontal',
@@ -119,7 +120,8 @@
     // Create new svg object
     this.svg = Chartist.createSvg(this.container, options.width, options.height, options.classNames.chart);
     // Create groups for labels, grid and series
-    var gridGroup = this.svg.elem('g').addClass(options.classNames.gridGroup);
+    var gridGroupVertical = this.svg.elem('g').addClass(options.classNames.gridGroupVertical);
+    var gridGroupHorizontal = this.svg.elem('g').addClass(options.classNames.gridGroupHorizontal);
     var seriesGroup = this.svg.elem('g');
     var labelGroup = this.svg.elem('g').addClass(options.classNames.labelGroup);
 
@@ -144,8 +146,8 @@
       axisY = options.axisY.type.call(Chartist, Chartist.Axis.units.y, data.normalized.series, chartRect, options.axisY);
     }
 
-    axisX.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
-    axisY.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
+    axisX.createGridAndLabels(gridGroupHorizontal, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
+    axisY.createGridAndLabels(gridGroupVertical, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
 
     if (options.showGridBackground) {
       Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -152,7 +152,7 @@
     axisY.createGridAndLabels(gridGroupVertical, labelGroupVertical, this.supportsForeignObject, options, this.eventEmitter);
 
     if (options.showGridBackground) {
-      Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);
+      Chartist.createGridBackground(gridGroupHorizontal, chartRect, options.classNames.gridBackground, this.eventEmitter);
     }
 
     // Draw the series

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -94,7 +94,8 @@
     classNames: {
       chart: 'ct-chart-line',
       label: 'ct-label',
-      labelGroup: 'ct-labels',
+      labelGroupVertical: 'ct-labels-vertical',
+      labelGroupHorizontal: 'ct-labels-horizontal',
       series: 'ct-series',
       line: 'ct-line',
       point: 'ct-point',
@@ -123,7 +124,8 @@
     var gridGroupVertical = this.svg.elem('g').addClass(options.classNames.gridGroupVertical);
     var gridGroupHorizontal = this.svg.elem('g').addClass(options.classNames.gridGroupHorizontal);
     var seriesGroup = this.svg.elem('g');
-    var labelGroup = this.svg.elem('g').addClass(options.classNames.labelGroup);
+    var labelGroupVertical = this.svg.elem('g').addClass(options.classNames.labelGroupVertical);
+    var labelGroupHorizontal = this.svg.elem('g').addClass(options.classNames.labelGroupHorizontal);
 
     var chartRect = Chartist.createChartRect(this.svg, options, defaultOptions.padding);
     var axisX, axisY;
@@ -146,8 +148,8 @@
       axisY = options.axisY.type.call(Chartist, Chartist.Axis.units.y, data.normalized.series, chartRect, options.axisY);
     }
 
-    axisX.createGridAndLabels(gridGroupHorizontal, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
-    axisY.createGridAndLabels(gridGroupVertical, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
+    axisX.createGridAndLabels(gridGroupHorizontal, labelGroupHorizontal, this.supportsForeignObject, options, this.eventEmitter);
+    axisY.createGridAndLabels(gridGroupVertical, labelGroupVertical, this.supportsForeignObject, options, this.eventEmitter);
 
     if (options.showGridBackground) {
       Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);

--- a/test/spec/spec-bar-chart.js
+++ b/test/spec/spec-bar-chart.js
@@ -40,17 +40,18 @@ describe('Bar chart tests', function() {
       chart.on('created', fn);      
     }
 
-    it('should contain ct-grids group', function(done) {
+    it('should contain ct-grids groups', function(done) {
       onCreated(function () {
-        expect($('g.ct-grids').length).toBe(1);        
+        expect($('g.ct-grids-horizontal').length).toBe(1);        
+        expect($('g.ct-grids-vertical').length).toBe(1);        
         done();
       });
     });
 
     it('should draw grid lines', function(done) {
       onCreated(function () {
-        expect($('g.ct-grids line.ct-grid.ct-horizontal').length).toBe(3);
-        expect($('g.ct-grids line.ct-grid.ct-vertical').length).toBe(6);        
+        expect($('g.ct-grids-horizontal line.ct-grid.ct-horizontal').length).toBe(3);
+        expect($('g.ct-grids-vertical line.ct-grid.ct-vertical').length).toBe(6);        
         done();
       });
     });
@@ -58,7 +59,7 @@ describe('Bar chart tests', function() {
     it('should draw grid background', function(done) {
       options.showGridBackground = true;
       onCreated(function () {
-        expect($('g.ct-grids rect.ct-grid-background').length).toBe(1);
+        expect($('g.ct-grids-horizontal rect.ct-grid-background').length).toBe(1);
         done();
       });
     });
@@ -66,7 +67,7 @@ describe('Bar chart tests', function() {
     it('should not draw grid background if option set to false', function(done) {
       options.showGridBackground = false;
       onCreated(function () {
-        expect($('g.ct-grids rect.ct-grid-background').length).toBe(0);
+        expect($('g.ct-grids-horizontal rect.ct-grid-background').length).toBe(0);
         done();
       });
     });

--- a/test/spec/spec-bar-chart.js
+++ b/test/spec/spec-bar-chart.js
@@ -272,7 +272,7 @@ describe('Bar chart tests', function() {
 
       chart.on('created', function () {
         // Find first and last label
-        var labels = document.querySelectorAll('.ct-labels .ct-label.ct-vertical');
+        var labels = document.querySelectorAll('.ct-labels-vertical .ct-label.ct-vertical');
         var firstLabel = labels[0];
         var lastLabel = labels[labels.length - 1];
 

--- a/test/spec/spec-bar-chart.js
+++ b/test/spec/spec-bar-chart.js
@@ -230,9 +230,9 @@ describe('Bar chart tests', function() {
 
       chart.on('created', function () {
         // Find at least one vertical grid line
-        expect(document.querySelector('.ct-grids .ct-grid.ct-vertical')).toBeDefined();
+        expect(document.querySelector('.ct-grids-vertical .ct-grid.ct-vertical')).toBeDefined();
         // Find exactly as many horizontal grid lines as labels were specified (Step Axis)
-        expect(document.querySelectorAll('.ct-grids .ct-grid.ct-horizontal').length).toBe(data.labels.length);
+        expect(document.querySelectorAll('.ct-grids-horizontal .ct-grid.ct-horizontal').length).toBe(data.labels.length);
         done();
       });
     });
@@ -251,9 +251,9 @@ describe('Bar chart tests', function() {
 
       chart.on('created', function () {
         // Find at least one vertical grid line
-        expect(document.querySelector('.ct-grids .ct-grid.ct-vertical')).toBeDefined();
+        expect(document.querySelector('.ct-grids-vertical .ct-grid.ct-vertical')).toBeDefined();
         // Should generate the labels using the largest series count
-        expect(document.querySelectorAll('.ct-grids .ct-grid.ct-horizontal').length).toBe(Math.max.apply(null, data.series.map(function(series) {
+        expect(document.querySelectorAll('.ct-grids-horizontal .ct-grid.ct-horizontal').length).toBe(Math.max.apply(null, data.series.map(function(series) {
           return series.length;
         })));
         done();

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -40,17 +40,18 @@ describe('Line chart tests', function () {
       chart.on('created', fn);
     }
 
-    it('should contain ct-grids group', function(done) {
+    it('should contain ct-grids groups', function(done) {
       onCreated(function () {
-        expect($('g.ct-grids').length).toBe(1);
+        expect($('g.ct-grids-horizontal').length).toBe(1);
+        expect($('g.ct-grids-vertical').length).toBe(1);
         done();
       });
     });
 
     it('should draw grid lines', function(done) {
       onCreated(function () {
-        expect($('g.ct-grids line.ct-grid.ct-horizontal').length).toBe(3);
-        expect($('g.ct-grids line.ct-grid.ct-vertical').length).toBe(5);
+        expect($('g.ct-grids-horizontal line.ct-grid.ct-horizontal').length).toBe(3);
+        expect($('g.ct-grids-vertical line.ct-grid.ct-vertical').length).toBe(5);
         done();
       });
     });
@@ -58,7 +59,7 @@ describe('Line chart tests', function () {
     it('should draw grid background', function(done) {
       options.showGridBackground = true;
       onCreated(function () {
-        expect($('g.ct-grids rect.ct-grid-background').length).toBe(1);
+        expect($('g.ct-grids-horizontal rect.ct-grid-background').length).toBe(1);
         done();
       });
     });
@@ -66,7 +67,7 @@ describe('Line chart tests', function () {
     it('should not draw grid background if option set to false', function(done) {
       options.showGridBackground = false;
       onCreated(function () {
-        expect($('g.ct-grids rect.ct-grid-background').length).toBe(0);
+        expect($('g.ct-grids-horizontal rect.ct-grid-background').length).toBe(0);
         done();
       });
     });

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -552,7 +552,7 @@ describe('Line chart tests', function () {
 
       chart.on('created', function () {
         // Find first and last label
-        var labels = document.querySelectorAll('.ct-labels .ct-label.ct-vertical');
+        var labels = document.querySelectorAll('.ct-labels-vertical .ct-label.ct-vertical');
         var firstLabel = labels[0];
         var lastLabel = labels[labels.length - 1];
 

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -510,9 +510,9 @@ describe('Line chart tests', function () {
 
       chart.on('created', function () {
         // Find at least one vertical grid line
-        expect(document.querySelector('.ct-grids .ct-grid.ct-vertical')).toBeDefined();
+        expect(document.querySelector('.ct-grids-vertical .ct-grid.ct-vertical')).toBeDefined();
         // Find exactly as many horizontal grid lines as labels were specified (Step Axis)
-        expect(document.querySelectorAll('.ct-grids .ct-grid.ct-horizontal').length).toBe(data.labels.length);
+        expect(document.querySelectorAll('.ct-grids-horizontal .ct-grid.ct-horizontal').length).toBe(data.labels.length);
         done();
       });
     });
@@ -531,9 +531,9 @@ describe('Line chart tests', function () {
 
       chart.on('created', function () {
         // Find at least one vertical grid line
-        expect(document.querySelector('.ct-grids .ct-grid.ct-vertical')).toBeDefined();
+        expect(document.querySelector('.ct-grids-vertical .ct-grid.ct-vertical')).toBeDefined();
         // Should generate the labels using the largest series count
-        expect(document.querySelectorAll('.ct-grids .ct-grid.ct-horizontal').length).toBe(Math.max.apply(null, data.series.map(function(series) {
+        expect(document.querySelectorAll('.ct-grids-horizontal .ct-grid.ct-horizontal').length).toBe(Math.max.apply(null, data.series.map(function(series) {
           return series.length;
         })));
         done();


### PR DESCRIPTION
This makes styling the grid much more flexible, because it allows css selectors such as ":first-child", ":last-child", ":nth-child(even)", etc to be used.
