### PR TITLE
Set the summary option to jasmine task to better analyse failed tests.

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
         '<%= pkg.config.src %>/scripts/charts/pie.js'
       ],
       options: {
+        summary: true,
         specs: '<%= pkg.config.test %>/spec/**/spec-*.js',
         helpers: '<%= pkg.config.test %>/spec/**/helper-*.js',
         vendor: [


### PR DESCRIPTION
This option displays a list of all failed tests and their failure messages.
We won't have to scroll the output for failures any more.
