### PR TITLE
Add grid background

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -85,6 +85,8 @@
     distributeSeries: false,
     // If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
     reverseData: false,
+    // If the bar chart should add a background fill to the .ct-grids group.
+    showGridBackground: false,
     // Override the class names that get used to generate the SVG structure of the chart
     classNames: {
       chart: 'ct-chart-bar',
@@ -95,6 +97,7 @@
       bar: 'ct-bar',
       grid: 'ct-grid',
       gridGroup: 'ct-grids',
+      gridBackground: 'ct-grid-background',
       vertical: 'ct-vertical',
       horizontal: 'ct-horizontal',
       start: 'ct-start',
@@ -225,6 +228,10 @@
 
     labelAxis.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
     valueAxis.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
+
+    if (options.showGridBackground) {
+      Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);
+    }
 
     // Draw the series
     data.raw.series.forEach(function(series, seriesIndex) {

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -69,11 +69,13 @@
     showPoint: true,
     // If the line chart should draw an area
     showArea: false,
-    // The base for the area chart that will be used to close the area shape (is normally 0)
+    // The base for the area chart that will be used to close the area shape (is normally 0)    
     areaBase: 0,
     // Specify if the lines should be smoothed. This value can be true or false where true will result in smoothing using the default smoothing interpolation function Chartist.Interpolation.cardinal and false results in Chartist.Interpolation.none. You can also choose other smoothing / interpolation functions available in the Chartist.Interpolation module, or write your own interpolation function. Check the examples for a brief description.
     lineSmooth: true,
-    // Overriding the natural low of the chart allows you to zoom in or limit the charts lowest displayed value
+    // If the line chart should add a background fill to the .ct-grids group.
+    showGridBackground: false,
+    // Overriding the natural low of the chart allows you to zoom in or limit the charts lowest displayed value    
     low: undefined,
     // Overriding the natural high of the chart allows you to zoom in or limit the charts highest displayed value
     high: undefined,
@@ -99,6 +101,7 @@
       area: 'ct-area',
       grid: 'ct-grid',
       gridGroup: 'ct-grids',
+      gridBackground: 'ct-grid-background',
       vertical: 'ct-vertical',
       horizontal: 'ct-horizontal',
       start: 'ct-start',
@@ -148,6 +151,11 @@
     axisX.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
     axisY.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
 
+    if (options.showGridBackground) {
+
+      Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);
+    }
+    
     // Draw the series
     data.raw.series.forEach(function(series, seriesIndex) {
       var seriesElement = seriesGroup.elem('g');

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -152,7 +152,6 @@
     axisY.createGridAndLabels(gridGroup, labelGroup, this.supportsForeignObject, options, this.eventEmitter);
 
     if (options.showGridBackground) {
-
       Chartist.createGridBackground(gridGroup, chartRect, options.classNames.gridBackground, this.eventEmitter);
     }
     

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -875,6 +875,31 @@ var Chartist = {
   };
 
   /**
+   * Creates a grid background rect and emits the draw event.
+   *
+   * @memberof Chartist.Core
+   * @param gridGroup
+   * @param chartRect
+   * @param className
+   * @param eventEmitter
+   */
+  Chartist.createGridBackground = function (gridGroup, chartRect, className, eventEmitter) {
+    var gridBackground = gridGroup.elem('rect', {
+        x: chartRect.x1,
+        y: chartRect.y2,
+        width: chartRect.width(),
+        height: chartRect.height(),
+      }, className, true);
+
+      // Event for grid background draw
+      eventEmitter.emit('draw', {
+        type: 'gridBackground',
+        group: gridGroup,
+        element: gridBackground
+      });
+  };
+
+  /**
    * Creates a label based on a projected value and an axis.
    *
    * @memberof Chartist.Core

--- a/src/styles/chartist.scss
+++ b/src/styles/chartist.scss
@@ -188,6 +188,10 @@
     @include ct-chart-grid($ct-grid-color, $ct-grid-width, $ct-grid-dasharray);
   }
 
+  .#{$ct-class-grid-background} {
+    fill: $ct-grid-background-fill;
+  }
+
   .#{$ct-class-point} {
     @include ct-chart-point($ct-point-size, $ct-point-shape);
   }

--- a/src/styles/settings/_chartist-settings.scss
+++ b/src/styles/settings/_chartist-settings.scss
@@ -18,6 +18,7 @@ $ct-class-bar: ct-bar !default;
 $ct-class-slice-pie: ct-slice-pie !default;
 $ct-class-slice-donut: ct-slice-donut !default;
 $ct-class-grid: ct-grid !default;
+$ct-class-grid-background: ct-grid-background !default;
 $ct-class-vertical: ct-vertical !default;
 $ct-class-horizontal: ct-horizontal !default;
 $ct-class-start: ct-start !default;
@@ -37,6 +38,7 @@ $ct-text-line-height: 1;
 $ct-grid-color: rgba(0, 0, 0, 0.2) !default;
 $ct-grid-dasharray: 2px !default;
 $ct-grid-width: 1px !default;
+$ct-grid-background-fill: none !default;
 
 // Line chart properties
 $ct-line-width: 4px !default;

--- a/test/spec/spec-bar-chart.js
+++ b/test/spec/spec-bar-chart.js
@@ -9,6 +9,71 @@ describe('Bar chart tests', function() {
 
   });
 
+  describe('grids', function() {
+    
+    var chart;
+    var options;
+    var data;
+
+    beforeEach(function() {
+      data = {
+        series: [[
+          { x: 1, y: 1 },
+          { x: 3, y: 5 }
+        ]]
+      };
+      options =  {
+        axisX: {
+          type: Chartist.AutoScaleAxis,
+          onlyInteger: true
+        },
+        axisY: {
+          type: Chartist.AutoScaleAxis,
+          onlyInteger: true
+        }
+      };
+    });
+
+    function onCreated(fn) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');  
+      chart = new Chartist.Bar('.ct-chart', data, options);
+      chart.on('created', fn);      
+    }
+
+    it('should contain ct-grids group', function(done) {
+      onCreated(function () {
+        expect($('g.ct-grids').length).toBe(1);        
+        done();
+      });
+    });
+
+    it('should draw grid lines', function(done) {
+      onCreated(function () {
+        expect($('g.ct-grids line.ct-grid.ct-horizontal').length).toBe(3);
+        expect($('g.ct-grids line.ct-grid.ct-vertical').length).toBe(6);        
+        done();
+      });
+    });
+
+    it('should draw grid background', function(done) {
+      options.showGridBackground = true;
+      onCreated(function () {
+        expect($('g.ct-grids rect.ct-grid-background').length).toBe(1);
+        done();
+      });
+    });
+
+    it('should not draw grid background if option set to false', function(done) {
+      options.showGridBackground = false;
+      onCreated(function () {
+        expect($('g.ct-grids rect.ct-grid-background').length).toBe(0);
+        done();
+      });
+    });
+
+  });
+
+
   describe('ct:value attribute', function() {
     it('should contain x and y value for each bar', function(done) {
       jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');

--- a/test/spec/spec-core.js
+++ b/test/spec/spec-core.js
@@ -524,4 +524,54 @@ describe('Chartist core', function() {
     });
 
   });
+
+  describe('createGridBackground', function() {
+    var group, chartRect, className, eventEmitter;
+
+    beforeEach(function() {
+      eventEmitter = Chartist.EventEmitter();
+      group = new Chartist.Svg('g');
+      className = 'ct-test';
+      chartRect = {
+        x1 : 5, 
+        y2 : 10,
+        _width : 100,
+        _height : 50,
+        width : function() { return this._width; },
+        height : function() { return this._height; },
+      };
+    });
+
+    function onCreated(fn, done) {
+      eventEmitter.addEventHandler('draw', function(data) {
+        fn(data);
+        done();
+      });
+      Chartist.createGridBackground(group, chartRect, className, eventEmitter);
+    }
+
+    it('should add rect', function(done) {
+      onCreated(function() {
+        var rects = group.querySelectorAll('rect').svgElements;        
+        expect(rects.length).toBe(1);
+        var rect = rects[0];
+        expect(rect.attr('x')).toBe('5');
+        expect(rect.attr('y')).toBe('10');
+        expect(rect.attr('width')).toBe('100');
+        expect(rect.attr('height')).toBe('50');
+        expect(rect.classes()).toEqual(['ct-test']);
+      }, done);            
+    });
+
+    it('should pass grid to event', function(done) {
+      onCreated(function(data) {
+        expect(data.type).toBe('gridBackground');
+        var rect = data.element;        
+        expect(rect.attr('x')).toBe('5');
+        expect(rect.attr('y')).toBe('10');
+      }, done);
+    });
+
+
+  });
 });

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -9,6 +9,71 @@ describe('Line chart tests', function () {
 
   });
 
+  describe('grids', function() {
+    
+    var chart;
+    var options;
+    var data;
+
+    beforeEach(function() {
+      data = {
+        series: [[
+          { x: 1, y: 1 },
+          { x: 3, y: 5 }
+        ]]
+      };
+      options =  {
+        axisX: {
+          type: Chartist.AutoScaleAxis,
+          onlyInteger: true
+        },
+        axisY: {
+          type: Chartist.AutoScaleAxis,
+          onlyInteger: true
+        }
+      };
+    });
+
+    function onCreated(fn) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');  
+      chart = new Chartist.Line('.ct-chart', data, options);
+      chart.on('created', fn);      
+    }
+
+    it('should contain ct-grids group', function(done) {
+      onCreated(function () {
+        expect($('g.ct-grids').length).toBe(1);        
+        done();
+      });
+    });
+
+    it('should draw grid lines', function(done) {
+      onCreated(function () {
+        expect($('g.ct-grids line.ct-grid.ct-horizontal').length).toBe(3);
+        expect($('g.ct-grids line.ct-grid.ct-vertical').length).toBe(5);        
+        done();
+      });
+    });
+
+    it('should draw grid background', function(done) {
+      options.showGridBackground = true;
+      onCreated(function () {
+        expect($('g.ct-grids rect.ct-grid-background').length).toBe(1);
+        done();
+      });
+    });
+
+    it('should not draw grid background if option set to false', function(done) {
+      options.showGridBackground = false;
+      onCreated(function () {
+        expect($('g.ct-grids rect.ct-grid-background').length).toBe(0);
+        done();
+      });
+    });
+
+  });
+
+
   describe('ct:value attribute', function () {
     it('should contain x and y value for each datapoint', function (done) {
       jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');


### PR DESCRIPTION
Implements #711 
Adds an option `showGridBackground` to line and bar charts (default is `false`).
If `true`, adds a `.ct-grids rect.ct-grid-background`.
