### PR TITLE
Add option for more tick control to AutoScaleAxis

### DIFF
--- a/src/scripts/axes/auto-scale-axis.js
+++ b/src/scripts/axes/auto-scale-axis.js
@@ -39,7 +39,7 @@
 
     if (!isNaN(parseFloat(options.ensureTickValue)) && ticks.indexOf(options.ensureTickValue) == -1) {
 
-      // redefine ticks by ensuring a given tick value and by preserving the calculated step size / interval
+      // Redefine ticks by ensuring a given tick value and by preserving the calculated step size / interval
       ticks = [];
       var currTick = options.ensureTickValue;
       var tickStep = this.bounds.step;
@@ -54,7 +54,7 @@
       ticks = ticks.reverse();
       this.bounds.min = currTick;
 
-      // Step up from the ensured value to generate higher tick values and define a new maximum limit
+      // Step up from the ensured tick value to generate higher tick values and define a new maximum limit
       currTick = options.ensureTickValue;
       ticks.push(currTick);
       while (currTick < maxTick) {
@@ -63,7 +63,7 @@
       }
       this.bounds.max = currTick;
 
-      // redefine bounds properties by new ticks, minimum and maximum limit
+      // Redefine bounds properties by new ticks, minimum and maximum limits
       this.bounds.valueRange = this.bounds.range = this.bounds.max - this.bounds.min;
       this.bounds.numberOfSteps = ticks.length;
 

--- a/src/scripts/axes/auto-scale-axis.js
+++ b/src/scripts/axes/auto-scale-axis.js
@@ -27,10 +27,6 @@
     // Usually we calculate highLow based on the data but this can be overriden by a highLow object in the options
     var highLow = options.highLow || Chartist.getHighLow(data.normalized, options, axisUnit.pos);
     this.bounds = Chartist.getBounds(chartRect[axisUnit.rectEnd] - chartRect[axisUnit.rectStart], highLow, options.scaleMinSpace || 20, options.onlyInteger);
-    this.range = {
-      min: this.bounds.min,
-      max: this.bounds.max
-    };
 
     var ticks = this.bounds.values;
     if (options.ticks) {
@@ -40,6 +36,43 @@
         return a - b;
       });
     }
+
+    if (!isNaN(parseFloat(options.ensureTickValue)) && ticks.indexOf(options.ensureTickValue) == -1) {
+
+      // redefine ticks by ensuring a given tick value and by preserving the calculated step size / interval
+      ticks = [];
+      var currTick = options.ensureTickValue;
+      var tickStep = this.bounds.step;
+      var minTick = this.bounds.min;
+      var maxTick = this.bounds.max;
+
+      // Step down from the ensured tick value to generate lower tick values and define a new minimum limit
+      while (currTick > minTick) {
+        currTick -= tickStep;
+        ticks.push(Chartist.roundWithPrecision(currTick));
+      }
+      ticks = ticks.reverse();
+      this.bounds.min = currTick;
+
+      // Step up from the ensured value to generate higher tick values and define a new maximum limit
+      currTick = options.ensureTickValue;
+      ticks.push(currTick);
+      while (currTick < maxTick) {
+        currTick += tickStep;
+        ticks.push(Chartist.roundWithPrecision(currTick));
+      }
+      this.bounds.max = currTick;
+
+      // redefine bounds properties by new ticks, minimum and maximum limit
+      this.bounds.valueRange = this.bounds.range = this.bounds.max - this.bounds.min;
+      this.bounds.numberOfSteps = ticks.length;
+
+    }
+
+    this.range = {
+      min: this.bounds.min,
+      max: this.bounds.max
+    };
 
     Chartist.AutoScaleAxis.super.constructor.call(this,
       axisUnit,

--- a/test/spec/spec-axes.js
+++ b/test/spec/spec-axes.js
@@ -1,6 +1,79 @@
 describe('Axes tests', function() {
   'use strict';
 
+  describe('auto scale axis', function () {
+
+    var axisUnit, chartRect, options, genericAsAxis, otherAsAxis;
+
+    beforeEach(function() {
+      axisUnit = {
+        'pos':'y',
+        'len':'height',
+        'dir':'vertical',
+        'rectStart':'y2',
+        'rectEnd':'y1',
+        'rectOffset':'x1'
+      };
+      chartRect = {
+        'padding':{'top':15,'right':15,'bottom':5,'left':10},
+        'y2':15,
+        'y1':141,
+        'x1':50,
+        'x2':269
+      };
+      options = {
+        highLow: {
+          high: 8.2,
+          low: -1
+        }
+      };
+      genericAsAxis = new Chartist.AutoScaleAxis(axisUnit, {}, chartRect, options);
+
+    });
+
+    it('should ensure the inclusion of a tick value set in axis options', function() {
+
+      // proves the possibility of ticks not including a value like 0
+      // (0 is probably the most popular use case here)
+      expect(genericAsAxis.bounds.step).toEqual(2);
+      expect(genericAsAxis.ticks).not.toContain(0);
+      expect(genericAsAxis.ticks).toEqual([ -1, 1, 3, 5, 7, 9 ]);
+
+      // preserves step size but ensures the inclusion of zero in ticks
+      options.ensureTickValue = 0;
+      otherAsAxis = new Chartist.AutoScaleAxis(axisUnit, {}, chartRect, options);
+      expect(otherAsAxis.bounds.step).toEqual(genericAsAxis.bounds.step);
+      expect(otherAsAxis.ticks).toContain(0);
+
+    });
+
+    it('should ensure the inclusion of a floating number as well', function() {
+      options.ensureTickValue = -1.25;
+      otherAsAxis = new Chartist.AutoScaleAxis(axisUnit, {}, chartRect, options);
+      expect(otherAsAxis.bounds.step).toEqual(genericAsAxis.bounds.step);
+      expect(otherAsAxis.ticks).toContain(-1.25);
+    });
+
+    it('should re-set the bound\'s range and maximum value if the ensured tick value is larger than the calculated maximum', function() {
+      options.ensureTickValue = 250;
+      otherAsAxis = new Chartist.AutoScaleAxis(axisUnit, {}, chartRect, options);
+      expect(otherAsAxis.bounds.step).toEqual(genericAsAxis.bounds.step);
+      expect(otherAsAxis.bounds.range).toBeGreaterThan(genericAsAxis.bounds.range);
+      expect(otherAsAxis.bounds.max).toEqual(250);
+      expect(otherAsAxis.ticks).toContain(250);
+    });
+
+    it('should re-set the bound\'s range and minimum value if the ensured tick value is lower than the calculated minimum', function() {
+      options.ensureTickValue = -250;
+      otherAsAxis = new Chartist.AutoScaleAxis(axisUnit, {}, chartRect, options);
+      expect(otherAsAxis.bounds.step).toEqual(genericAsAxis.bounds.step);
+      expect(otherAsAxis.bounds.range).toBeGreaterThan(genericAsAxis.bounds.range);
+      expect(otherAsAxis.ticks).toContain(-250);
+      expect(otherAsAxis.bounds.min).toEqual(-250);
+    });
+
+  });
+
   describe('fixed scale axis', function () {
     it('should order the tick array', function() {
 


### PR DESCRIPTION
I think a feature that enables to override calculated ticks with "static ticks" would not really help us in our case (it maybe helps in other cases). In the example I showed in the other PR (http://jsbin.com/fufevozevi/edit?html,js,output) the resulting scale of the y axis does not include zero (`-1,1,3,5,7`), however we don't want it to become something like this instead: `-1,0,1,3,5,7`. With your suggested override feature, this could now easily be achieved by setting `axisY:{ ticks:[0] }`.

We'd rather like to preserve a regular interval to get a scale like this: `-2,0,2,4,6,8` . That means it's not enough to only set/override one (or more) ticks, but the new ticks also need to get recalculated dynamically in stepping up and down from a tick value by the given interval. So it was my concept to not only ensure a certain tick value, but also to step up and down from it. In the end, the calculation results in complete new ticks.

I understand you not wanting to include this in the `getBounds()` function because this could lead to a certain overload. What I suggest you instead is to insert the recalculation of the ticks as part of the AutoScaleAxis where you suggested the tick override feature. I know that the code is still quite similar to what I suggested before, but I still think this is the way to go to solve this issue. Please let me know what you think about it.
