### PR TITLE
Add default colors to total of 26, so there won't be unrendered lines

### DIFF
--- a/src/styles/settings/_chartist-settings.scss
+++ b/src/styles/settings/_chartist-settings.scss
@@ -67,7 +67,7 @@ $ct-include-colored-series: $ct-include-classes !default;
 $ct-include-alternative-responsive-containers: $ct-include-classes !default;
 
 // Series names and colors. This can be extended or customized as desired. Just add more series and colors.
-$ct-series-names: (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) !default;
+$ct-series-names: (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) !default;
 $ct-series-colors: (
   #d70206,
   #f05b4f,
@@ -83,5 +83,16 @@ $ct-series-colors: (
   #86797d,
   #b2c326,
   #6188e2,
-  #a748ca
+  #a748ca,
+  #c32222,
+  #c35822,
+  #c38e22,
+  #c3c322,
+  #8ec322,
+  #58c322,
+  #22c322,
+  #22c358,
+  #22c38e,
+  #22c3c3,
+  #228ec3
 ) !default;


### PR DESCRIPTION
This works as a non-breaking (albeit might change colours for some) fix for the problem that ct-series from -p to -z are left blank because of missing stroke colors.
Fixes permanently problems like with:
- #354 
- #451 
- #714 

I also spent good many hours identifying this problem, it was hard to spot because it became apparent only after 15 series and was very unexpected of charting library.

I took the colors from here:
[http://jsbin.com/zozelilomi/edit?css,js,output](http://jsbin.com/zozelilomi/edit?css,js,output)
