### PR TITLE
Adds grunt-assemble plugin to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "assemble-dox": "0.0.2",
     "grunt": "^1.0.1",
+    "grunt-assemble": "^0.4.0",
     "grunt-concurrent": "^2.3.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",


### PR DESCRIPTION
Adding this dependency to the package.json allows the grunt task "assemble" to succeed. Currently (following the contribution guide), It fails when running `grunt preview` and other commands.

Issue #744 
