### PR TITLE
Fix stack overflow bug caused by array allocation

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -140,7 +140,7 @@ var Chartist = {
    * @return {Array}
    */
   Chartist.times = function(length) {
-    return Array.apply(null, new Array(length));
+    return Array.from(Array(length), () => null);
   };
 
   /**


### PR DESCRIPTION
Calling `Chartist.times` with a `length` larger than the maximum call stack size would cause the following error:

```
chartist.js:163 Uncaught RangeError: Maximum call stack size exceeded
```

This is due to the way the array is being allocated.

As discussed in the elm-dev Slack team (quote reproduced below), the fastest way to allocate an array with arbitrary (null) values is as per this PR, using `Array.from`.
### Justification

richard feldman: I was chatting with David Nolen once about implementing persistent data structures in JS, and he said the ClojureScript folks benchmarked a ton of approaches, and the most surprising takeaway was that allocating an array of 32 nulls (as in the JS literal `[null, null, null null, …` - writing out all 32 of them by hand in a single literal, which was apparently very important) blew all other initial allocation approaches they tried out of the water, like 3x faster than the second-fastest. 
[archive link](https://elmlang.slack.com/archives/elm-dev/p1470848937001769)
