### PR TITLE
Fixed a bug of updating chart under scale transforming

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -796,8 +796,8 @@ var Chartist = {
     var yAxisOffset = hasAxis ? options.axisY.offset : 0;
     var xAxisOffset = hasAxis ? options.axisX.offset : 0;
     // If width or height results in invalid value (including 0) we fallback to the unitless settings or even 0
-    var width = svg.width() || Chartist.quantity(options.width).value || 0;
-    var height = svg.height() || Chartist.quantity(options.height).value || 0;
+    var width = Chartist.quantity(options.width).value || svg.width() || 0;
+    var height = Chartist.quantity(options.height).value || svg.height() || 0;
     var normalizedPadding = Chartist.normalizePadding(options.chartPadding, fallbackPadding);
 
     // If settings were to small to cope with offset (legacy) and padding, we'll adjust


### PR DESCRIPTION
There is a bug when refreshing the chart under scale transforming: the
zoom size of the chart will be square of the scale value.

Demo: http://codepen.io/Dafrok/pen/oLRxka
