### PR TITLE
Fix #403 - Add amdModuleId

### DIFF
--- a/tasks/umd.js
+++ b/tasks/umd.js
@@ -15,6 +15,7 @@ module.exports = function (grunt) {
       src: '<%= pkg.config.dist %>/chartist.js',
       objectToExport: 'Chartist',
       globalAlias: 'Chartist',
+      amdModuleId: 'Chartist',
       indent: '  '
     }
   };


### PR DESCRIPTION
Needed for webpacking scripts - sets name correctly
