### PR TITLE
Fix holes for x/y series data

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -1068,7 +1068,8 @@ var Chartist = {
 
     for(var i = 0; i < pathCoordinates.length; i += 2) {
       // If this value is a "hole" we set the hole flag
-      if(valueData[i / 2].value === undefined) {
+      var value = valueData[i/2].value;
+      if(value === undefined || (value && value.y === undefined)) {
         if(!options.fillHoles) {
           hole = true;
         }

--- a/src/scripts/interpolation.js
+++ b/src/scripts/interpolation.js
@@ -40,7 +40,7 @@
         var currY = pathCoordinates[i + 1];
         var currData = valueData[i / 2];
 
-        if(currData.value !== undefined) {
+        if(currData.value !== undefined && currData.value.y !== undefined) {
 
           if(hole) {
             path.move(currX, currY, false, currData);
@@ -100,7 +100,7 @@
         var length = (currX - prevX) * d;
         var currData = valueData[i / 2];
 
-        if(currData.value !== undefined) {
+        if(currData.value !== undefined && currData.value.y !== undefined) {
 
           if(prevData === undefined) {
             path.move(currX, currY, false, currData);


### PR DESCRIPTION
Hole checks weren’t accounting for .y values. This fixed that.
