### PR TITLE
Fix for #783 NaN for PieChart with sum values zero

### DIFF
--- a/src/scripts/charts/pie.js
+++ b/src/scripts/charts/pie.js
@@ -163,7 +163,8 @@
         (series.className || options.classNames.series + '-' + Chartist.alphaNumerate(i))
       ].join(' '));
 
-      var endAngle = startAngle + dataArray[i] / totalDataSum * 360;
+      // If the whole dataset is 0 endAngle should be zero. Can't divide by 0.
+      var endAngle = (totalDataSum > 0 ? startAngle + dataArray[i] / totalDataSum * 360 : 0);
 
       // Use slight offset so there are no transparent hairline issues
       var overlappigStartAngle = Math.max(0, startAngle - (i === 0 || hasSingleValInSeries ? 0 : 0.2));

--- a/test/spec/spec-pie-chart.js
+++ b/test/spec/spec-pie-chart.js
@@ -252,6 +252,39 @@ describe('Pie chart tests', function() {
     });
   });
 
+  describe('Pie with empty values', function() {
+    var data;
+
+    beforeEach(function() {
+      data = {
+        series: [0, 0, 0]
+      };
+    });
+
+    function onCreated(callback) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+      var chart = new Chartist.Pie('.ct-chart', data, {});
+      chart.on('created', callback);
+    }
+
+    it('Pie should render without NaN values and points', function(done) {
+      onCreated(function() {
+        var slices = $('.ct-slice-pie');
+
+        expect(slices.length).toBe(3);
+
+        expect(slices.eq(2).attr('ct:value')).toBe('0');
+        expect(slices.eq(1).attr('ct:value')).toBe('0');
+        expect(slices.eq(0).attr('ct:value')).toBe('0');
+
+        expect(slices.eq(2).attr('d')).toBe('M200,5A118.609,118.609,0,0,0,200,5L200,123.609Z');
+        expect(slices.eq(1).attr('d')).toBe('M200,5A118.609,118.609,0,0,0,200,5L200,123.609Z');
+        expect(slices.eq(0).attr('d')).toBe('M200,5A118.609,118.609,0,0,0,200,5L200,123.609Z');
+        done();
+      });
+    });
+  });
+
   describe('Pie with some empty values configured not to be ignored', function() {
     var data, options;
 


### PR DESCRIPTION
Hi, I was not quite sure how to write a test for this. Since testing console output seems like a bad idea. 

If you have any comments on this implementation I'd love to hear them! 😄 

This fixes and issue presented by #783 where console errors are printed when the total sum of series is 0. Chartist tries to generate an svg to an endpoint NaN, by dividing by 0.
