### PR TITLE
Suggested fix for #713 position of axisY labels

### DIFF
--- a/src/scripts/axes/axis.js
+++ b/src/scripts/axes/axis.js
@@ -97,7 +97,7 @@
         Chartist.createLabel(projectedValue, labelLength, index, labelValues, this, axisOptions.offset, labelOffset, labelGroup, [
           chartOptions.classNames.label,
           chartOptions.classNames[this.units.dir],
-          chartOptions.classNames[axisOptions.position]
+          (axisOptions.position === 'start' ? chartOptions.classNames[axisOptions.position] : chartOptions.classNames['end'])
         ], useForeignObject, eventEmitter);
       }
     }.bind(this));

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -73,6 +73,54 @@ describe('Line chart tests', function () {
 
   });
 
+  describe('AxisY position tests', function() {
+    var options;
+    var data;
+
+    beforeEach(function() {
+      data = {
+        series: [[
+          { x: 1, y: 1 },
+          { x: 3, y: 5 }
+        ]]
+      };
+      options =  {};
+    });
+
+    function onCreated(callback) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+      var chart = new Chartist.Line('.ct-chart', data, options);
+      chart.on('created', callback);
+    }
+
+    it('class should be ct-start if position start', function(done) {
+      options = {
+        axisY: {
+          position: 'start'
+        }
+      }
+      onCreated(function() {
+          $('.ct-label.ct-vertical').each(function() {
+            expect($(this).attr('class')).toBe('ct-label ct-vertical ct-start');
+          });
+          done();
+        });
+      });
+
+    it('class should be ct-end if position is any other value than start', function(done) {
+      options = {
+        axisY: {
+          position: 'right'
+        }
+      }      
+      onCreated(function() {
+        $('.ct-label.ct-vertical').each(function() {
+          expect($(this).attr('class')).toBe('ct-label ct-vertical ct-end');
+        });
+        done();
+      });
+    });
+  });
 
   describe('ct:value attribute', function () {
     it('should contain x and y value for each datapoint', function (done) {


### PR DESCRIPTION
If the position is not specifically set to 'start' default the position to 'end'. Any other value is not allowed, both possible values are explicitly mentioned in the documentation.
