### PR TITLE
Fix error in function StepAxis returning NaN 

### DIFF
--- a/src/scripts/axes/step-axis.js
+++ b/src/scripts/axes/step-axis.js
@@ -24,7 +24,8 @@
       options.ticks,
       options);
 
-    this.stepLength = this.axisLength / (options.ticks.length - (options.stretch ? 1 : 0));
+    var calc = (options.ticks.length - (options.stretch ? 1 : 0));
+    this.stepLength = this.axisLength / (calc === 0 ? 1 : calc);
   }
 
   function projectValue(value, index) {

--- a/test/spec/spec-line-chart.js
+++ b/test/spec/spec-line-chart.js
@@ -502,4 +502,24 @@ describe('Line chart tests', function () {
       });
     });
   });
+  
+  describe('x1 and x2 attribute', function () {
+    it('should contain just a datapoint', function (done) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+  
+      var chart = new Chartist.Line('.ct-chart', {
+        series: [[
+          {x: 1, y: 2}
+        ]]
+      }, {
+       fullWidth: true
+      });
+  
+      chart.on('created', function () {
+        expect($('.ct-point').eq(0).attr('x1')).not.toBe('NaN');
+        expect($('.ct-point').eq(0).attr('x2')).not.toBe('NaN');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
![screen shot 2016-10-04 at 5 49 45 pm](https://cloud.githubusercontent.com/assets/3471145/19091965/15bf1d36-8a5b-11e6-85e1-2b5b2b15a619.png)

In line chart with **fullWidth: true**, the function StepAxis is occurring a division by zero, therefore is returning _NaN_ to attributes **x1** and **x2** of axis.

This PR correct this follow issue: https://github.com/gionkunz/chartist-js/issues/716
