### PR TITLE
Fix handling of holes in interpolation for multi-value series

### DIFF
--- a/site/examples/example-line-data-fill-holes.js
+++ b/site/examples/example-line-data-fill-holes.js
@@ -3,7 +3,8 @@ var chart = new Chartist.Line('.ct-chart', {
   series: [
     [5, 5, 10, 8, 7, 5, 4, null, null, null, 10, 10, 7, 8, 6, 9],
     [10, 15, null, 12, null, 10, 12, 15, null, null, 12, null, 14, null, null, null],
-    [null, null, null, null, 3, 4, 1, 3, 4,  6,  7,  9, 5, null, null, null]
+    [null, null, null, null, 3, 4, 1, 3, 4,  6,  7,  9, 5, null, null, null],
+    [{x:3, y: 3},{x: 4, y: 3}, {x: 5, y: undefined}, {x: 6, y: 4}, {x: 7, y: null}, {x: 8, y: 4}, {x: 9, y: 4}]
   ]
 }, {
   fullWidth: true,

--- a/site/examples/example-line-data-holes.js
+++ b/site/examples/example-line-data-holes.js
@@ -3,7 +3,8 @@ var chart = new Chartist.Line('.ct-chart', {
   series: [
     [5, 5, 10, 8, 7, 5, 4, null, null, null, 10, 10, 7, 8, 6, 9],
     [10, 15, null, 12, null, 10, 12, 15, null, null, 12, null, 14, null, null, null],
-    [null, null, null, null, 3, 4, 1, 3, 4,  6,  7,  9, 5, null, null, null]
+    [null, null, null, null, 3, 4, 1, 3, 4,  6,  7,  9, 5, null, null, null],
+    [{x:3, y: 3},{x: 4, y: 3}, {x: 5, y: undefined}, {x: 6, y: 4}, {x: 7, y: null}, {x: 8, y: 4}, {x: 9, y: 4}]
   ]
 }, {
   fullWidth: true,

--- a/src/scripts/axes/auto-scale-axis.js
+++ b/src/scripts/axes/auto-scale-axis.js
@@ -40,7 +40,7 @@
   }
 
   function projectValue(value) {
-    return this.axisLength * (+Chartist.getMultiValue(value, this.units.pos) - this.bounds.min) / this.bounds.range;
+    return this.axisLength * (+Chartist.getMultiValue(value, this.units.pos, 0) - this.bounds.min) / this.bounds.range;
   }
 
   Chartist.AutoScaleAxis = Chartist.Axis.extend({

--- a/src/scripts/axes/fixed-scale-axis.js
+++ b/src/scripts/axes/fixed-scale-axis.js
@@ -45,7 +45,7 @@
   }
 
   function projectValue(value) {
-    return this.axisLength * (+Chartist.getMultiValue(value, this.units.pos) - this.range.min) / (this.range.max - this.range.min);
+    return this.axisLength * (+Chartist.getMultiValue(value, this.units.pos, 0) - this.range.min) / (this.range.max - this.range.min);
   }
 
   Chartist.FixedScaleAxis = Chartist.Axis.extend({

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -586,7 +586,7 @@ var Chartist = {
    * @returns {Boolean}
    */
   Chartist.isNum = function(value) {
-    return !isNaN(value) && isFinite(value);
+    return (typeof value === "number" || typeof value === "string") && !isNaN(value) && isFinite(value);
   };
 
   /**
@@ -608,23 +608,24 @@ var Chartist = {
    * @returns {*}
    */
   Chartist.getNumberOrUndefined = function(value) {
-    return isNaN(+value) ? undefined : +value;
+    return Chartist.isNum(value) ? +value : undefined;
   };
 
   /**
-   * Gets a value from a dimension `value.x` or `value.y` while returning value directly if it's a valid numeric value. If the value is not numeric and it's falsey this function will return undefined.
+   * Gets a value from a dimension `value.x` or `value.y` while returning value directly if it's a valid numeric value. If the value is not numeric and it's falsey this function will return `defaultValue`.
    *
    * @param value
    * @param dimension
+   * @param defaultValue
    * @returns {*}
    */
-  Chartist.getMultiValue = function(value, dimension) {
+  Chartist.getMultiValue = function(value, dimension, defaultValue) {
     if(Chartist.isNum(value)) {
       return +value;
     } else if(value) {
-      return value[dimension || 'y'] || 0;
+      return Chartist.isFalseyButZero(value[dimension || 'y']) ? defaultValue : value[dimension || 'y'];
     } else {
-      return 0;
+      return defaultValue;
     }
   };
 
@@ -1068,7 +1069,8 @@ var Chartist = {
 
     for(var i = 0; i < pathCoordinates.length; i += 2) {
       // If this value is a "hole" we set the hole flag
-      if(valueData[i / 2].value === undefined) {
+      if(Chartist.getMultiValue(valueData[i / 2].value) === undefined) {
+      // if(valueData[i / 2].value === undefined) {
         if(!options.fillHoles) {
           hole = true;
         }

--- a/src/scripts/interpolation.js
+++ b/src/scripts/interpolation.js
@@ -40,7 +40,7 @@
         var currY = pathCoordinates[i + 1];
         var currData = valueData[i / 2];
 
-        if(currData.value !== undefined) {
+        if(Chartist.getMultiValue(currData.value) !== undefined) {
 
           if(hole) {
             path.move(currX, currY, false, currData);


### PR DESCRIPTION
This PR fixes issue https://github.com/gionkunz/chartist-js/issues/633

I haven't added any new tests, but all existing tests pass. I've added a multi value series to the holes in data examples which demonstrates the fix.

I had to change some logic in core functions `Chartist.isNum` and `Chartist.getNumberOrUndefined` and `Chartist.getMultiValue` because these functions did not handle `null` properly.
