### PR TITLE
Use .offset* instead of .getBoundingClientRect

### DIFF
--- a/src/scripts/svg.js
+++ b/src/scripts/svg.js
@@ -314,23 +314,23 @@
   }
 
   /**
-   * Get element height using `getBoundingClientRect`
+   * Get element height using `offsetHeight`
    *
    * @memberof Chartist.Svg
    * @return {Number} The elements height in pixels
    */
   function height() {
-    return this._node.getBoundingClientRect().height;
+    return this._node.offsetHeight;
   }
 
   /**
-   * Get element width using `getBoundingClientRect`
+   * Get element width using `offsetHeight`
    *
    * @memberof Chartist.Core
    * @return {Number} The elements width in pixels
    */
   function width() {
-    return this._node.getBoundingClientRect().width;
+    return this._node.offsetWidth;
   }
 
   /**


### PR DESCRIPTION
`getBoundingClientRect` returns the actual displayed size of the component, which is usually the same as `offsetHeight` `offsetWidth`. That doesn't work when a CSS transform is applied, in which case we need the logical size of the element, not the actual one.

See:
https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements