### PR TITLE
Update tablepress_chartist github url

### DIFF
--- a/site/data/pages/index.yml
+++ b/site/data/pages/index.yml
@@ -232,7 +232,7 @@ sections:
               - '<a href="https://github.com/mfpierre/meteor-chartist-js" target="_blank">meteor-chartist-js</a>'
               - Meteor Package
             -
-              - '<a href="https://github.com/soderlind/tablepress_chartist" target="_blank">tablepress_chartist</a>'
+              - '<a href="https://github.com/silsha/tablepress_chartist" target="_blank">tablepress_chartist</a>'
               - Wordpress / Tablepress Extension
             -
               - '<a href="https://github.com/tylergaw/ember-cli-chartist" target="_blank">ember-cli-chartist</a>'


### PR DESCRIPTION
I've been in contact with soderlind and I'll continue development of his project.

The plugin is also back in the wordpress directory: https://wordpress.org/plugins/charts-for-tablepress-chartist/