### PR TITLE
Add 'parameters' attribute on bars

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -354,12 +354,14 @@
         positions.y1 = Math.min(Math.max(positions.y1, chartRect.y2), chartRect.y1);
         positions.y2 = Math.min(Math.max(positions.y2, chartRect.y2), chartRect.y1);
 
-        var metaData = Chartist.getMetaData(series, valueIndex);
+        var metaData = Chartist.getDataFromSelector(series, valueIndex, 'meta');
+        var parametersData = Chartist.getDataFromSelector(series, valueIndex, 'parameters');
 
         // Create bar element
         bar = seriesElement.elem('line', positions, options.classNames.bar).attr({
           'ct:value': [value.x, value.y].filter(Chartist.isNumeric).join(','),
-          'ct:meta': Chartist.serialize(metaData)
+          'ct:meta': Chartist.serialize(metaData),
+          'ct:parameters': Chartist.serialize(parametersData)
         });
 
         this.eventEmitter.emit('draw', Chartist.extend({
@@ -367,6 +369,7 @@
           value: value,
           index: valueIndex,
           meta: metaData,
+          parameters: parametersData,
           series: series,
           seriesIndex: seriesIndex,
           axisX: axisX,

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -179,7 +179,7 @@
         pathData.push({
           value: value,
           valueIndex: valueIndex,
-          meta: Chartist.getMetaData(series, valueIndex)
+          meta: Chartist.getDataFromSelector(series, valueIndex, 'meta')
         });
       }.bind(this));
 

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -496,9 +496,9 @@ var Chartist = {
     };
   };
 
-  Chartist.getMetaData = function(series, index) {
+  Chartist.getDataFromSelector = function(series, index, selector) {
     var value = series.data ? series.data[index] : series[index];
-    return value ? value.meta : undefined;
+    return value ? value[selector] : undefined;
   };
 
   /**

--- a/test/spec/spec-bar-chart.js
+++ b/test/spec/spec-bar-chart.js
@@ -10,7 +10,7 @@ describe('Bar chart tests', function() {
   });
 
   describe('grids', function() {
-    
+
     var chart;
     var options;
     var data;
@@ -35,14 +35,14 @@ describe('Bar chart tests', function() {
     });
 
     function onCreated(fn) {
-      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');  
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
       chart = new Chartist.Bar('.ct-chart', data, options);
-      chart.on('created', fn);      
+      chart.on('created', fn);
     }
 
     it('should contain ct-grids group', function(done) {
       onCreated(function () {
-        expect($('g.ct-grids').length).toBe(1);        
+        expect($('g.ct-grids').length).toBe(1);
         done();
       });
     });
@@ -50,7 +50,7 @@ describe('Bar chart tests', function() {
     it('should draw grid lines', function(done) {
       onCreated(function () {
         expect($('g.ct-grids line.ct-grid.ct-horizontal').length).toBe(3);
-        expect($('g.ct-grids line.ct-grid.ct-vertical').length).toBe(6);        
+        expect($('g.ct-grids line.ct-grid.ct-vertical').length).toBe(6);
         done();
       });
     });
@@ -167,6 +167,32 @@ describe('Bar chart tests', function() {
 
       chart.on('created', function() {
         expect(Chartist.deserialize($('.ct-bar').eq(3).attr('ct:meta'))).toEqual(meta);
+        done();
+      });
+    });
+
+    it('should render parameters data correctly with mixed value array and different normalized data length', function(done) {
+      jasmine.getFixtures().set('<div class="ct-chart ct-golden-section"></div>');
+
+      var parameters = {
+        test: 'Serialized Test',
+        title: 'Serialized Test Title'
+      };
+
+      var data = {
+        labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+        series: [
+          [5, 2, 4, {
+            value: 2,
+            parameters: parameters
+          }, 0]
+        ]
+      };
+
+      var chart = new Chartist.Bar('.ct-chart', data);
+
+      chart.on('created', function() {
+        expect(Chartist.deserialize($('.ct-bar').eq(3).attr('ct:parameters'))).toEqual(parameters);
         done();
       });
     });


### PR DESCRIPTION
### Why?
I came across an issue where I needed more information on graph bars that `meta` or `value` could provide.

### Solution
Add a new attribute called `parameters` that can be an object or anything the user needs to provide more information on every bar.

I've also renamed `getMetaData`  for `getDataFromSelector` because the path to extract data from `parameters` is the same as the one for `meta`. 

