### PR TITLE
Fix bug with removing non-existent SVG

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -308,7 +308,9 @@ var Chartist = {
     Array.prototype.slice.call(container.querySelectorAll('svg')).filter(function filterChartistSvgObjects(svg) {
       return svg.getAttributeNS(Chartist.namespaces.xmlns, 'ct');
     }).forEach(function removePreviousElement(svg) {
-      container.removeChild(svg);
+      if (container.contains(svg)) {
+        container.removeChild(svg);
+      }
     });
 
     // Create svg object with width and height or use 100% as default


### PR DESCRIPTION
Assume, we have a line chart with custom SVG points, like in this example
https://gionkunz.github.io/chartist-js/examples.html#example-line-modify-drawing
and we draw custom SVG something like this
```
var shape = new Chartist.Svg('svg', null, 'ct-dot ct-shape');
        new Chartist.Svg('circle', {
          cx: [data.x], cy: [data.y], r: [13]
        }, 'ct-border-circle', shape);
        new Chartist.Svg('circle', {
          cx: [data.x], cy: [data.y], r: [7]
        }, 'ct-in-circle', shape);
        new Chartist.Svg('circle', {
          cx: [data.x], cy: [data.y], r: [10]
        }, 'ct-out-circle', shape);
```

Then custom SVG points get default namespace and when chart updates this code
```
svg.getAttributeNS(Chartist.namespaces.xmlns, 'ct');
```
return the chart itself as a first element and its custom SVG children as next elements. Then
```
container.removeChild(svg);
```
remove the chart itself on a first step and throw the error on a second, because custom SVG children are no longer exists.

I've added checking that prevents this situation.