### PR TITLE
Added targetline plugin

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "chartist-plugin-threshold": "~0.0.1",
     "chartist-plugin-fill-donut": "~0.0.1",
     "chartist-plugin-zoom": "~0.2.1",
+    "chartist-plugin-targetline": "~1.0.0",
     "matchMedia": "~0.2.0",
     "moment": "^2.14.1"
   },

--- a/site/data/pages/plugins.yml
+++ b/site/data/pages/plugins.yml
@@ -252,6 +252,30 @@ sections:
                   -
                     - '<strong>Link:</strong>'
                     - '<a href="https://github.com/hansmaad/chartist-plugin-zoom" target="_blank">chartist-plugin-zoom</a>'
+      - type: sub-section
+        data:
+          title: Target Line Plugin
+          level: 4
+          items:
+            - type: text
+              data:
+                text: >
+                        The target line plugin allows you to draw a target line on your chart.
+            - type: live-example
+              data:
+                id: example-plugin-targetline
+                classes: ct-golden-section
+                intro: >
+                          Pass a value to the plugin to draw a target line on the chart.
+            - type: table
+              data:
+                rows:
+                  -
+                    - '<strong>Author:</strong>'
+                    - Harry Twyford
+                  -
+                    - '<strong>Link:</strong>'
+                    - '<a href="https://github.com/htwyford/chartist-plugin-targetline" target="_blank">chartist-plugin-targetline</a>'
   - title: Develop a plugin
     level: 3
     items:

--- a/site/examples/example-plugin-targetline.js
+++ b/site/examples/example-plugin-targetline.js
@@ -1,0 +1,12 @@
+new Chartist.Line('.ct-chart', {
+  labels: ['M', 'T', 'W', 'T', 'F'],
+  series: [
+    [5, 11, 2, 5, 7]
+  ]
+}, {
+  plugins: [
+    Chartist.plugins.ctTargetLine({
+      value: 6
+    })
+  ]
+});

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -77,6 +77,7 @@
 <script src="bower_components/chartist-plugin-threshold/dist/chartist-plugin-threshold.js"></script>
 <script src="bower_components/chartist-plugin-fill-donut/dist/chartist-plugin-fill-donut.js"></script>
 <script src="bower_components/chartist-plugin-zoom/dist/chartist-plugin-zoom.js"></script>
+<script src="bower_components/chartist-plugin-targetline/chartist-plugin-targetline.js"></script>
 
 <!-- Chartist site scripts -->
 <script src="scripts/main.js"></script>


### PR DESCRIPTION
Adds chartist-plugin-targetline plugin. As discussed in #235 and available at https://github.com/htwyford/chartist-plugin-targetline