### PR TITLE
Added additional 'ct:index' to the dom elements

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -358,6 +358,7 @@
 
         // Create bar element
         bar = seriesElement.elem('line', positions, options.classNames.bar).attr({
+          'ct:index': valueIndex,
           'ct:value': [value.x, value.y].filter(Chartist.isNumeric).join(','),
           'ct:meta': Chartist.serialize(metaData)
         });

--- a/src/scripts/charts/line.js
+++ b/src/scripts/charts/line.js
@@ -209,6 +209,7 @@
             x2: pathElement.x + 0.01,
             y2: pathElement.y
           }, options.classNames.point).attr({
+            'ct:index': pathElement.data.valueIndex,
             'ct:value': [pathElement.data.value.x, pathElement.data.value.y].filter(Chartist.isNumeric).join(','),
             'ct:meta': Chartist.serialize(pathElement.data.meta)
           });

--- a/src/scripts/charts/pie.js
+++ b/src/scripts/charts/pie.js
@@ -218,6 +218,7 @@
 
       // Adding the pie series value to the path
       pathElement.attr({
+        'ct:index': index,
         'ct:value': data.normalized.series[index],
         'ct:meta': Chartist.serialize(series.meta)
       });


### PR DESCRIPTION
As described in this [PR for the Tooltip-Plugin](https://github.com/tmmdata/chartist-plugin-tooltip/pull/135) it can be helpful to have access to the current index in certain circumstances. 