### PR TITLE
Add crosshair cursor plugin to the examples page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "chartist-plugin-fill-donut": "~0.0.1",
     "chartist-plugin-zoom": "~0.2.1",
     "chartist-plugin-targetline": "~1.0.0",
+    "chartist-plugin-crosshairCursor": "v1.0",
     "matchMedia": "~0.2.0",
     "moment": "^2.14.1"
   },

--- a/site/data/pages/plugins.yml
+++ b/site/data/pages/plugins.yml
@@ -57,6 +57,31 @@ sections:
 
       - type: sub-section
         data:
+          title: Crosshair Cursor Plugin
+          level: 4
+          items:
+            - type: text
+              data:
+                text: >
+                        The crosshair cursor plugin easily adds a customizable data crosshair to your line charts, making it super simple to quickly access more information about your chart data.
+            - type: live-example
+              data:
+                id: example-plugin-crosshairCursor
+                classes: ct-golden-section
+                intro: >
+                         Hover over the chart to quickly see meta data about your highlighted points logged below. Click to freeze the cursor in place at any position.
+            - type: table
+              data:
+                rows:
+                  -
+                    - '<strong>Author:</strong>'
+                    - Sroop Sunar
+                  -
+                    - '<strong>Link:</strong>'
+                    - '<a href="https://github.com/sroop/chartist-plugin-crosshairCursor" target="_blank">chartist-plugin-crosshairCursor</a>'
+
+      - type: sub-section
+        data:
           title: Accessibility Plugin
           level: 4
           items:

--- a/site/examples/example-plugin-crosshairCursor.js
+++ b/site/examples/example-plugin-crosshairCursor.js
@@ -1,0 +1,68 @@
+resetChart()
+
+var chart = new Chartist.Line('.ct-chart', {
+labels: ['A', 'B', 'C', 'D', 'E'],
+  series: [
+    {
+      name: 'line',
+      data: [
+        {value: 12, meta: {id: 1, title: "First point"}},
+        {value: 9, meta: {id: 2, title: "Second point"}},
+        {value: 7, meta: {id: 3, title: "Third point"}},
+        {value: 9, meta: {id: 4, title: "Fourth point"}},
+        {value:5, meta: {id: 5, title: "Fifth point"}}
+      ]
+    }
+  ]}, {
+    fullWidth: true,
+    chartPadding: {
+      right: 40
+    },
+    plugins: [
+      Chartist.plugins.crosshairCursor({
+        wrapperName: '.ct-golden-section',
+        type: 'full', // 'x' 'y' or 'full'
+        clickToFreeze: true, // true or false
+        sendDataOn: 'hover' // 'hover' or 'click'
+      })
+    ]
+  }
+);
+
+chart.on('crosshairCursor:frozen', function(isFrozen) {
+  $('.crosshairCursor-frozenStatus').text("Frozen: " + isFrozen);
+}, false);
+
+chart.on('crosshairCursor:hovered', function(highlightedPoints) {
+  $('.crosshairCursor-hoveredInfo').text("Highlighted points: " + JSON.stringify(highlightedPoints));
+}, false);
+
+
+
+
+
+// Create logging area below the chart for displaying available meta data
+
+function createLoggingArea(id, text) {
+  var container = document.createElement('div');
+  container.className = "crosshairCursor-" + id;
+  container.innerText = text;
+  var chartWrapper = $('.crosshairCursor-wrapper');
+  chartWrapper.after(container);
+}
+
+chart.on('created', function() {
+  $('.crosshairCursor-hoveredInfo').remove()
+  $('.crosshairCursor-frozenStatus').remove()
+  createLoggingArea('hoveredInfo', "Highlighted points: []");
+  createLoggingArea('frozenStatus', "Frozen: false");
+})
+
+function resetChart() {
+  var ctChart = $('#example-plugin-crosshairCursor.edit-mode .ct-chart')
+  ctChart.unwrap()
+  $('#crosshairCursor-x').remove()
+  $('#crosshairCursor-y').remove()
+  $('.crosshairCursor-hoveredInfo').remove()
+  $('.crosshairCursor-frozenStatus').remove()
+}

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -78,6 +78,7 @@
 <script src="bower_components/chartist-plugin-fill-donut/dist/chartist-plugin-fill-donut.js"></script>
 <script src="bower_components/chartist-plugin-zoom/dist/chartist-plugin-zoom.js"></script>
 <script src="bower_components/chartist-plugin-targetline/chartist-plugin-targetline.js"></script>
+<script src="bower_components/chartist-plugin-crosshairCursor/dist/chartist-plugin-crosshairCursor.js"></script>
 
 <!-- Chartist site scripts -->
 <script src="scripts/main.js"></script>

--- a/site/styles/_example-charts.scss
+++ b/site/styles/_example-charts.scss
@@ -142,3 +142,27 @@
   .chartist-tooltip.tooltip-show {
     opacity: 1; }
 }
+
+#example-plugin-crosshairCursor {
+  #crosshairCursor-x, #crosshairCursor-y {
+    background-color: #FFDA34 !important;
+  }
+  .ct-point {
+    stroke: #d70206;
+  }
+  .ct-point.crosshairCursor-highlight {
+    stroke: #FFDA34;
+  }
+  .crosshairCursor-hoveredInfo {
+    background-color: rgba(0, 0, 0, 0.1);
+    height: 100px;
+    padding: 20px;
+    font-size: 12px;
+  }
+  .crosshairCursor-frozenStatus {
+    background-color: rgba(0, 0, 0, 0.1);
+    height: 30px;
+    padding: 20px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
# Chartist Crosshair Cursor Plugin
The crosshair cursor plugin easily adds a customizable data crosshair to your line charts, making it super simple to quickly access more information about your chart data.

More information about the various options and installation can be found in [this repo](https://github.com/sroop/chartist-plugin-crosshairCursor). You can see it in action [here](https://sroop.github.io/chartist-plugin-crosshairCursor/example.html) and in the plugin examples page of this PR (preview image below).

## Preview

![screen shot 2017-12-10 at 14 47 58](https://user-images.githubusercontent.com/7127533/33806006-2f3133e6-ddb9-11e7-8bb7-85bbda714bc9.png)

Thanks! 
