### PR TITLE
Added cname file to point to free js.org domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+chartist.js.org


### PR DESCRIPTION
Since chartist does not have an easy to remember domain how about using the free [js.org](js.org) service to register [chartist.js.org](chartist.js.org).

If this pull request is accepted the next step would simply be to make a pull request to [this repo](https://github.com/js-org/js.org/tree/master) to add chartist.js.org.