### PR TITLE
Use HTML DOM style for setting label overflow as well

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -982,9 +982,8 @@ var Chartist = {
       content.style[axis.units.len] = Math.round(positionalData[axis.units.len]) + 'px';
       content.style[axis.counterUnits.len] = Math.round(positionalData[axis.counterUnits.len]) + 'px';
 
-      labelElement = group.foreignObject(content, Chartist.extend({
-        style: 'overflow: visible;'
-      }, positionalData));
+      labelElement = group.foreignObject(content, positionalData);
+      labelElement._node.style.overflow = 'visible';
     } else {
       labelElement = group.elem('text', positionalData, classes.join(' ')).text(labels[index]);
     }


### PR DESCRIPTION
PR #928 fixed most inline style errors from Content Security Policy, but it missed this one. This fixes another error by again using `style` to add the style rule.