### PR TITLE
Bugfix: only calculate high low from stacked values if stackMode is accumulate

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -140,7 +140,7 @@
     var seriesGroup = this.svg.elem('g');
     var labelGroup = this.svg.elem('g').addClass(options.classNames.labelGroup);
 
-    if(options.stackBars && data.normalized.series.length !== 0) {
+    if(options.stackBars && (options.stackMode === 'accumulate' || !options.stackMode) && data.normalized.series.length !== 0) {
 
       // If stacked bars we need to calculate the high low from stacked values from each series
       var serialSums = Chartist.serialMap(data.normalized.series, function serialSums() {


### PR DESCRIPTION
When not accumulating totals in stacked bar charts, the high / low values should not do so either.

Turns this:
![afbeelding](https://user-images.githubusercontent.com/885856/67688583-5ce06380-f99a-11e9-8426-9b1cbd1da4c7.png)

Into this:
![afbeelding](https://user-images.githubusercontent.com/885856/67688632-71bcf700-f99a-11e9-8fa3-6af952efe35b.png)

