### PR TITLE
Add class name of series to its label element in pie charts

### DIFF
--- a/dist/chartist.js
+++ b/dist/chartist.js
@@ -4394,11 +4394,14 @@ var Chartist = {
         var interpolatedValue = options.labelInterpolationFnc(rawValue, index);
 
         if(interpolatedValue || interpolatedValue === 0) {
+          // Get custom className or 'default' className of this series, so we can add it to the labelElement
+          var labelClassName = data.raw.series[index].className || options.classNames.series + '-' + Chartist.alphaNumerate(index)
+
           var labelElement = labelsGroup.elem('text', {
             dx: labelPosition.x,
             dy: labelPosition.y,
             'text-anchor': determineAnchorPosition(center, labelPosition, options.labelDirection)
-          }, options.classNames.label).text('' + interpolatedValue);
+          }, options.classNames.label + ' ' + labelClassName).text('' + interpolatedValue);
 
           // Fire off draw event
           this.eventEmitter.emit('draw', {


### PR DESCRIPTION
# Problem
This fixes [this issue](https://github.com/gionkunz/chartist-js/issues/942), it makes sure the labels get the same 'series-X' class name (or custom className if given) as their corresponding slices. This is needed because then we can style the labels without having to use 'nth-child'.

# Solution
Add className on the label element, that corresponds with the correct slice. Set
- custom className if set
- otherwise set 'series-X'


