### PR TITLE
docs: Fix simple typo, unncessary -> unnecessary

### DIFF
--- a/dist/chartist.js
+++ b/dist/chartist.js
@@ -4173,7 +4173,7 @@ var Chartist = {
     labelDirection: 'neutral',
     // If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
     reverseData: false,
-    // If true empty values will be ignored to avoid drawing unncessary slices and labels
+    // If true empty values will be ignored to avoid drawing unnecessary slices and labels
     ignoreEmptyValues: false
   };
 

--- a/src/scripts/charts/pie.js
+++ b/src/scripts/charts/pie.js
@@ -55,7 +55,7 @@
     labelDirection: 'neutral',
     // If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
     reverseData: false,
-    // If true empty values will be ignored to avoid drawing unncessary slices and labels
+    // If true empty values will be ignored to avoid drawing unnecessary slices and labels
     ignoreEmptyValues: false
   };
 


### PR DESCRIPTION
There is a small typo in dist/chartist.js, src/scripts/charts/pie.js.

Should read `unnecessary` rather than `unncessary`.

