### PR TITLE
Bugfix: summing up stacked bars with undefined items in series

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -148,8 +148,8 @@
           return value;
         }).reduce(function(prev, curr) {
           return {
-            x: prev.x + (curr && curr.x) || 0,
-            y: prev.y + (curr && curr.y) || 0
+            x: prev.x + ((curr && curr.x) || 0),
+            y: prev.y + ((curr && curr.y) || 0)
           };
         }, {x: 0, y: 0});
       });


### PR DESCRIPTION
When there are undefined items in the series, the summing of stacked bars goes wrong. 

Fixes #1254 