### PR TITLE
build: umd bundle and cdn fields in package.json

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -7,7 +7,7 @@
   },
   {
     "path": "dist/index.cjs",
-    "limit": "11.75 kB",
+    "limit": "7.3 kB",
     "import": "{ BarChart }"
   },
   {
@@ -18,7 +18,7 @@
   },
   {
     "path": "dist/index.js",
-    "limit": "9.2 kB",
+    "limit": "7.3 kB",
     "import": "{ BarChart }"
   },
   {

--- a/package.json
+++ b/package.json
@@ -40,13 +40,10 @@
   "main": "./src/index.ts",
   "publishConfig": {
     "main": "./dist/index.cjs",
-    "module": "./dist/index.esm.js",
-    "browser": {
-      "./dist/index.cjs": "./dist/index.umd.js"
-    },
+    "module": "./dist/index.js",
     "exports": {
       "require": "./dist/index.cjs",
-      "import": "./dist/index.esm.js"
+      "import": "./dist/index.js"
     },
     "directory": "package"
   },

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "style": "./src/styles/chartist.scss",
+  "style": "./dist/index.css",
+  "unpkg": "./dist/index.umd.js",
+  "jsdelivr": "./dist/index.umd.js",
   "main": "./src/index.ts",
   "publishConfig": {
-    "style": "./dist/index.css",
     "main": "./dist/index.cjs",
     "module": "./dist/index.esm.js",
     "browser": {
@@ -60,7 +61,7 @@
     "prepublishOnly": "pnpm test && pnpm build && pnpm clear:package && clean-publish",
     "postpublish": "pnpm clear:package",
     "emitDeclarations": "tsc --project ./tsconfig.build.json --emitDeclarationOnly",
-    "build:styles": "./scripts/styles.cjs",
+    "build:styles": "./scripts/styles.cjs ./src/styles/chartist.scss",
     "build": "rollup -c & pnpm build:styles & pnpm emitDeclarations",
     "start:storybook": "start-storybook -p 6006 --ci",
     "build:storybook": "del ./storybook-static; NODE_ENV=production build-storybook",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,17 +61,5 @@ export default [
       format: 'es',
       sourcemap: true
     }
-  },
-  {
-    input: pkg.main,
-    plugins: plugins('defaults, not ie 11, not ie_mob 11'),
-    external,
-    output: {
-      file: pkg.publishConfig.browser[pkg.publishConfig.main],
-      format: 'iife',
-      name: 'Chartist',
-      exports: 'named',
-      sourcemap: true
-    }
   }
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,27 +5,28 @@ import pkg from './package.json';
 
 const extensions = ['.js', '.ts', '.tsx'];
 const external = _ => /node_modules/.test(_) && !/@swc\/helpers/.test(_);
-const plugins = targets => [
-  nodeResolve({
-    extensions
-  }),
-  swc({
-    jsc: {
-      parser: {
-        syntax: 'typescript'
+const plugins = (targets, minify) =>
+  [
+    nodeResolve({
+      extensions
+    }),
+    swc({
+      jsc: {
+        parser: {
+          syntax: 'typescript'
+        },
+        externalHelpers: true
       },
-      externalHelpers: true
-    },
-    env: {
-      targets
-    },
-    module: {
-      type: 'es6'
-    },
-    sourceMaps: true
-  }),
-  terser()
-];
+      env: {
+        targets
+      },
+      module: {
+        type: 'es6'
+      },
+      sourceMaps: true
+    }),
+    minify && terser()
+  ].filter(Boolean);
 
 export default [
   {
@@ -34,6 +35,17 @@ export default [
     external,
     output: {
       file: pkg.publishConfig.main,
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true
+    }
+  },
+  {
+    input: pkg.main,
+    plugins: plugins('defaults, not ie 11, not ie_mob 11', true),
+    external: () => false,
+    output: {
+      file: pkg.unpkg,
       format: 'umd',
       name: 'Chartist',
       exports: 'named',

--- a/scripts/styles.cjs
+++ b/scripts/styles.cjs
@@ -9,14 +9,14 @@ const { plugins } = require('../postcss.config.cjs');
 const pkg = require('../package.json');
 
 const cwd = process.cwd();
-const input = pkg.style;
-const output = pkg.publishConfig.style;
-const sourceMapOutput = pkg.publishConfig.style.replace('.css', '.css.map');
+const input = process.argv[2];
+const output = pkg.style;
+const sourceMapOutput = output.replace('.css', '.css.map');
 
 (async () => {
   let styles;
 
-  styles = sass.compile(pkg.style, {
+  styles = sass.compile(input, {
     sourceMap: true
   });
 


### PR DESCRIPTION
## `exports.import`

- for isomorphic/universal Node.js (> 12 with `exports` field support) environments like SSR in ESM projects
- for Webpack 5
- for other modern bundlers with `exports` support

## `exports.require`

- for isomorphic/universal Node.js (> 12 with `exports` field support) environments like SSR in CommonJS projects

## `module`

- for Webpack 4
- for other old bundlers without `exports` field support

## `main`

- for isomorphic/universal Node.js (<= 12 without `exports` field support) environments like SSR in CommonJS projects 
- legacy bundlers like browserify 

## `unpkg`, `jsdelivr`

Shortcuts for CDN services. E. g. https://unpkg.com/chartist will point to https://unpkg.com/chartist/dist/index.umd.js



