### PR TITLE
fix: SvgPath.parse fails on negative values

### DIFF
--- a/src/svg/SvgPath.spec.ts
+++ b/src/svg/SvgPath.spec.ts
@@ -191,5 +191,17 @@ describe('Svg', () => {
       expect(paths[1].pathElements.length).toBe(4);
       expect(paths[1].pathElements[0].command).toBe('M');
     });
+
+    it('should correctly parse negative values', () => {
+      const paths: any = new SvgPath().parse('M-10,10L-100,-100');
+      expect(paths.pathElements.length).toBe(2);
+      expect(paths.pathElements[0].command).toBe('M');
+      expect(paths.pathElements[1].command).toBe('L');
+
+      expect(paths.pathElements[0].x).toBe(-10);
+      expect(paths.pathElements[0].y).toBe(10);
+      expect(paths.pathElements[1].x).toBe(-100);
+      expect(paths.pathElements[1].y).toBe(-100);
+    });
   });
 });

--- a/src/svg/SvgPath.ts
+++ b/src/svg/SvgPath.ts
@@ -255,7 +255,7 @@ export class SvgPath {
   parse(path: string) {
     // Parsing the SVG path string into an array of arrays [['M', '10', '10'], ['L', '100', '100']]
     const chunks = path
-      .replace(/([A-Za-z])([0-9])/g, '$1 $2')
+      .replace(/([A-Za-z])(-?[0-9])/g, '$1 $2')
       .replace(/([0-9])([A-Za-z])/g, '$1 $2')
       .split(/[\s,]+/)
       .reduce<string[][]>((result, pathElement) => {


### PR DESCRIPTION
Implements suggested fix from #1248.