### PR TITLE
fix: add missing default for -text-line-height

### DIFF
--- a/src/styles/_settings.scss
+++ b/src/styles/_settings.scss
@@ -34,7 +34,7 @@ $ct-text-color: rgba(0, 0, 0, 0.4) !default;
 $ct-text-size: 0.75rem !default;
 $ct-text-align: flex-start !default;
 $ct-text-justify: flex-start !default;
-$ct-text-line-height: 1;
+$ct-text-line-height: 1 !default;
 
 // Grid styles
 $ct-grid-color: rgba(0, 0, 0, 0.2) !default;


### PR DESCRIPTION
Fixes #1034.

Please ignore this PR if `!default` is actually missing for a reason.