### PR TITLE
feat: add an error message when chart container is not found

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -7,7 +7,7 @@
   },
   {
     "path": "dist/index.cjs",
-    "limit": "7.41 kB",
+    "limit": "7.45 kB",
     "import": "{ BarChart }"
   },
   {

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -7,7 +7,7 @@
   },
   {
     "path": "dist/index.cjs",
-    "limit": "7.40 kB",
+    "limit": "7.41 kB",
     "import": "{ BarChart }"
   },
   {

--- a/src/charts/BaseChart.ts
+++ b/src/charts/BaseChart.ts
@@ -32,7 +32,9 @@ export abstract class BaseChart<TEventsTypes = BaseChartEventsTypes> {
 
     if (!container) {
       throw new Error(
-        `Target element ${typeof query === 'string' ? `"${query}"` : ''} is not found`
+        `Target element ${
+          typeof query === 'string' ? `"${query}"` : ''
+        } is not found`
       );
     }
 

--- a/src/charts/BaseChart.ts
+++ b/src/charts/BaseChart.ts
@@ -32,7 +32,7 @@ export abstract class BaseChart<TEventsTypes = BaseChartEventsTypes> {
 
     if (!container) {
       throw new Error(
-        `Target element ${typeof query === 'string' ? query : ''} is not found`
+        `Target element ${typeof query === 'string' ? `"${query}"` : ''} is not found`
       );
     }
 

--- a/src/charts/BaseChart.ts
+++ b/src/charts/BaseChart.ts
@@ -31,7 +31,9 @@ export abstract class BaseChart<TEventsTypes = BaseChartEventsTypes> {
       typeof query === 'string' ? document.querySelector(query) : query;
 
     if (!container) {
-      throw new Error('Target element is not found');
+      throw new Error(
+        `Target element ${typeof query === 'string' ? query : ''} is not found`
+      );
     }
 
     this.container = container;

--- a/src/core/creation.ts
+++ b/src/core/creation.ts
@@ -27,6 +27,9 @@ export function createSvg(
   height: number | string = '100%',
   className?: string
 ) {
+  if (!container) {
+    throw new Error('Container element is not found');
+  }
   // Check if there is a previous SVG element in the container that contains the Chartist XML namespace and remove it
   // Since the DOM API does not support namespaces we need to manually search the returned list http://www.w3.org/TR/selectors-api/
   Array.from(container.querySelectorAll('svg'))

--- a/src/core/creation.ts
+++ b/src/core/creation.ts
@@ -30,6 +30,7 @@ export function createSvg(
   if (!container) {
     throw new Error('Container element is not found');
   }
+
   // Check if there is a previous SVG element in the container that contains the Chartist XML namespace and remove it
   // Since the DOM API does not support namespaces we need to manually search the returned list http://www.w3.org/TR/selectors-api/
   Array.from(container.querySelectorAll('svg'))


### PR DESCRIPTION
Fixes #1354.

Error message example:
![no-container-error-chartist](https://user-images.githubusercontent.com/48175583/209546049-dfaf848c-2893-48d0-acb0-e95e68b4b243.png)
