### PR TITLE
fix: use clientWidth/clientHeight instead of getBoundingClientRect

### DIFF
--- a/src/svg/Svg.ts
+++ b/src/svg/Svg.ts
@@ -330,19 +330,19 @@ export class Svg {
   }
 
   /**
-   * Get element height using `getBoundingClientRect`
+   * Get element height using `clientHeight`
    * @return The elements height in pixels
    */
   height() {
-    return this._node.getBoundingClientRect().height;
+    return this._node.clientHeight;
   }
 
   /**
-   * Get element width using `getBoundingClientRect`
+   * Get element width using `clientWidth`
    * @return The elements width in pixels
    */
   width() {
-    return this._node.getBoundingClientRect().width;
+    return this._node.clientWidth;
   }
 
   /**

--- a/test/mock/dom.ts
+++ b/test/mock/dom.ts
@@ -42,8 +42,32 @@ export function mockDomRects() {
     bottom: 0,
     left: 0
   });
+
+  Object.defineProperties(SVGElement.prototype, {
+    clientWidth: {
+      configurable: true,
+      get: () => 500
+    },
+    clientHeight: {
+      configurable: true,
+      get: () => 500
+    }
+  });
 }
 
 export function destroyMockDomRects() {
   SVGElement.prototype.getBoundingClientRect = getBoundingClientRect;
+
+  // Redefine clientWidth and clientHeight properties from the prototype of SVGElement
+  const ElementPrototype = Object.getPrototypeOf(SVGElement.prototype);
+  Object.defineProperties(SVGElement.prototype, {
+    clientWidth: Object.getOwnPropertyDescriptor(
+      ElementPrototype,
+      'clientWidth'
+    )!,
+    clientHeight: Object.getOwnPropertyDescriptor(
+      ElementPrototype,
+      'clientHeight'
+    )!
+  });
 }


### PR DESCRIPTION
Fixes #1065.

(Two tests fail on my PC both with and without my change. I verified one of them in my browser where the test passes.)