### PR TITLE
feat: add option to prevent overlapping labels

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,7 +1,7 @@
 [
   {
     "path": "dist/index.cjs",
-    "limit": "36.45 kB",
+    "limit": "36.62 kB",
     "webpack": false,
     "running": false
   },
@@ -12,7 +12,7 @@
   },
   {
     "path": "dist/index.js",
-    "limit": "36.2 kB",
+    "limit": "36.35 kB",
     "webpack": false,
     "running": false
   },

--- a/src/charts/PieChart/PieChart.stories.ts
+++ b/src/charts/PieChart/PieChart.stories.ts
@@ -45,13 +45,7 @@ export function OverlappingLabels() {
   new PieChart(
     root,
     {
-      labels: [
-        'Big Slice',
-        'Small Slice 1',
-        'Small Slice 2',
-        'Small Slice 3',
-        'Small Slice 4'
-      ],
+      labels: ['Big Slice', 11231231, 'Test the string', new Date(), 124124124],
       series: [96, 1, 1, 1, 1]
     },
     {

--- a/src/charts/PieChart/PieChart.stories.ts
+++ b/src/charts/PieChart/PieChart.stories.ts
@@ -39,6 +39,29 @@ export function Labels() {
   return root;
 }
 
+export function OverlappingLabels() {
+  const root = document.createElement('div');
+
+  new PieChart(
+    root,
+    {
+      labels: [
+        'Big Slice',
+        'Small Slice 1',
+        'Small Slice 2',
+        'Small Slice 3',
+        'Small Slice 4'
+      ],
+      series: [96, 1, 1, 1, 1]
+    },
+    {
+      preventOverlappingLabelOffset: 12
+    }
+  );
+
+  return root;
+}
+
 export function LabelInterpolation() {
   const root = document.createElement('div');
   const data = {

--- a/src/charts/PieChart/PieChart.ts
+++ b/src/charts/PieChart/PieChart.ts
@@ -193,10 +193,10 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
 
   /**
    * Check if a label has overlapping text then move it the number of pixels up and left based on textSize.
-   * 
+   *
    * @param lp Label position that chartist will be checking does not overlap with the list of LabelPositions.
    * @param lpExisting Label position that has already been placed that chartist will check against.
-   * @param textOffset this is configured with preventOverlappingLabelOffset option. 
+   * @param textOffset this is configured with preventOverlappingLabelOffset option.
    * @param length How many characters long the label is.
    */
   labelMover(lp: Dot, lpExisting: Dot, textOffset: number, length: number) {
@@ -210,7 +210,7 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
       lp.x -= textOffset;
       this.labelMover(lp, lpExisting, textOffset, length);
     }
-  };
+  }
 
   /**
    * Creates the pie chart
@@ -448,8 +448,8 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
           if (options.preventOverlappingLabelOffset) {
             const textSize: number = options.preventOverlappingLabelOffset;
             const length: number = // Tested with all three data types string, number, and date.
-              String(normalizedData.labels[index]).length ?? 1; // Default to 1 character length
-      
+              String(normalizedData.labels[index]).length ?? 0; // Default to 0 character length
+
             labelPositions.forEach(item => {
               this.labelMover(labelPosition, item, textSize, length);
             });

--- a/src/charts/PieChart/PieChart.ts
+++ b/src/charts/PieChart/PieChart.ts
@@ -428,8 +428,8 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
             const textSize = options.preventOverlappingLabelOffset;
 
             const labelMover = (lp: any, item: any) => {
-              const length =
-                (normalizedData.labels[index] as string)?.length ?? 1; // Default to 1 character length
+              const length = // Tested with all three data types string, number, and date.
+                ((normalizedData.labels[index] + '') as string)?.length ?? 1; // Default to 1 character length
 
               if (
                 lp.y > item.y - textSize &&

--- a/src/charts/PieChart/PieChart.ts
+++ b/src/charts/PieChart/PieChart.ts
@@ -71,7 +71,7 @@ const defaultOptions = {
   labelDirection: 'neutral',
   // If true empty values will be ignored to avoid drawing unnecessary slices and labels
   ignoreEmptyValues: false,
-  // If Nonzero check if a label has overlapping text then move it the number of pixels up and left (Should be label size)
+  // If Nonzero check if a label has overlapping text then move it the number of pixels up and left (Should be half of label font size + 1 but you can tweak it as you prefer)
   preventOverlappingLabelOffset: 0
 };
 

--- a/src/charts/PieChart/PieChart.ts
+++ b/src/charts/PieChart/PieChart.ts
@@ -193,22 +193,26 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
 
   /**
    * Check if a label has overlapping text then move it the number of pixels up and left based on textSize.
-   *
-   * @param lp Label position that chartist will be checking does not overlap with the list of LabelPositions.
-   * @param lpExisting Label position that has already been placed that chartist will check against.
-   * @param textOffset this is configured with preventOverlappingLabelOffset option.
-   * @param length How many characters long the label is.
+   * @param labelPos - Label position that chartist will be checking does not overlap with the list of LabelPositions.
+   * @param existingLabelPos - Label position that has already been placed that chartist will check against.
+   * @param textOffset - this is configured with preventOverlappingLabelOffset option.
+   * @param length - How many characters long the label is.
    */
-  labelMover(lp: Dot, lpExisting: Dot, textOffset: number, length: number) {
+  moveLabel(
+    labelPos: Dot,
+    existingLabelPos: Dot,
+    textOffset: number,
+    length: number
+  ) {
     if (
-      lp.y > lpExisting.y - textOffset &&
-      lp.y < lpExisting.y + textOffset &&
-      lp.x > lpExisting.x - length * textOffset &&
-      lp.x < lpExisting.x + length * textOffset
+      labelPos.y > existingLabelPos.y - textOffset &&
+      labelPos.y < existingLabelPos.y + textOffset &&
+      labelPos.x > existingLabelPos.x - length * textOffset &&
+      labelPos.x < existingLabelPos.x + length * textOffset
     ) {
-      lp.y -= textOffset;
-      lp.x -= textOffset;
-      this.labelMover(lp, lpExisting, textOffset, length);
+      labelPos.y -= textOffset;
+      labelPos.x -= textOffset;
+      this.moveLabel(labelPos, existingLabelPos, textOffset, length);
     }
   }
 
@@ -446,12 +450,11 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
 
         if (interpolatedValue || interpolatedValue === 0) {
           if (options.preventOverlappingLabelOffset) {
-            const textSize: number = options.preventOverlappingLabelOffset;
-            const length: number = // Tested with all three data types string, number, and date.
-              String(normalizedData.labels[index]).length ?? 0; // Default to 0 character length
+            const textOffset = options.preventOverlappingLabelOffset;
+            const length = String(normalizedData.labels[index]).length;
 
             labelPositions.forEach(item => {
-              this.labelMover(labelPosition, item, textSize, length);
+              this.moveLabel(labelPosition, item, textOffset, length);
             });
             labelPositions.push(labelPosition);
           }

--- a/src/charts/PieChart/PieChart.ts
+++ b/src/charts/PieChart/PieChart.ts
@@ -429,7 +429,7 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
 
             const labelMover = (lp: any, item: any) => {
               const length = // Tested with all three data types string, number, and date.
-                ((normalizedData.labels[index] + '') as string)?.length ?? 1; // Default to 1 character length
+                String(normalizedData.labels[index]).length ?? 1; // Default to 1 character length
 
               if (
                 lp.y > item.y - textSize &&

--- a/src/charts/PieChart/PieChart.ts
+++ b/src/charts/PieChart/PieChart.ts
@@ -70,7 +70,9 @@ const defaultOptions = {
   // Label direction can be 'neutral', 'explode' or 'implode'. The labels anchor will be positioned based on those settings as well as the fact if the labels are on the right or left side of the center of the chart. Usually explode is useful when labels are positioned far away from the center.
   labelDirection: 'neutral',
   // If true empty values will be ignored to avoid drawing unnecessary slices and labels
-  ignoreEmptyValues: false
+  ignoreEmptyValues: false,
+  // If Nonzero check if a label has overlapping text then move it the number of pixels up and left (Should be label size)
+  preventOverlappingLabelOffset: 0
 };
 
 /**
@@ -199,6 +201,7 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
     const normalizedData = normalizeData(data);
     const seriesGroups: Svg[] = [];
     let labelsGroup: Svg;
+    const labelPositions: any[] = [];
     let labelRadius: number;
     let startAngle = options.startAngle;
 
@@ -387,7 +390,7 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
 
       // If we need to show labels we need to add the label for this slice now
       if (options.showLabel) {
-        let labelPosition;
+        let labelPosition: any;
 
         if (data.series.length === 1) {
           // If we have only 1 series, we can position the label in the center of the pie
@@ -421,6 +424,31 @@ export class PieChart extends BaseChart<PieChartEventsTypes> {
         );
 
         if (interpolatedValue || interpolatedValue === 0) {
+          if (options.preventOverlappingLabelOffset) {
+            const textSize = options.preventOverlappingLabelOffset;
+
+            const labelMover = (lp: any, item: any) => {
+              const length =
+                (normalizedData.labels[index] as string)?.length ?? 1; // Default to 1 character length
+
+              if (
+                lp.y > item.y - textSize &&
+                lp.y < item.y + textSize &&
+                lp.x > item.x - length * textSize &&
+                lp.x < item.x + length * textSize
+              ) {
+                lp.y -= textSize;
+                lp.x -= textSize;
+                labelMover(lp, item);
+              }
+            };
+
+            labelPositions.forEach(item => {
+              labelMover(labelPosition, item);
+            });
+            labelPositions.push(labelPosition);
+          }
+
           const labelElement = labelsGroup
             .elem(
               'text',

--- a/src/charts/PieChart/PieChart.types.ts
+++ b/src/charts/PieChart/PieChart.types.ts
@@ -82,6 +82,10 @@ export interface PieChartOptions extends Omit<Options, 'axisX' | 'axisY'> {
    * If true empty values will be ignored to avoid drawing unnecessary slices and labels
    */
   ignoreEmptyValues?: boolean;
+  /**
+   * If nonzero labels will not overlap.
+   */
+  preventOverlappingLabelOffset?: number;
 }
 
 export type PieChartOptionsWithDefaults = RequiredKeys<
@@ -93,7 +97,8 @@ export type PieChartOptionsWithDefaults = RequiredKeys<
   | 'labelOffset'
   | 'labelPosition'
   | 'labelInterpolationFnc'
-  | 'labelDirection',
+  | 'labelDirection'
+  | 'preventOverlappingLabelOffset',
   'classNames'
 >;
 


### PR DESCRIPTION
Add an option to pie chart that can prevent overlapping labels. If preventOverlappingLabelOffset is Nonzero check if a label has overlapping text then move it the number of pixels up and left (Should be label size)