### PR TITLE
Css enhancements

### DIFF
--- a/src/charts/BarChart/BarChart.ts
+++ b/src/charts/BarChart/BarChart.ts
@@ -130,7 +130,7 @@ const defaultOptions = {
   showGridBackground: false,
   // Override the class names that get used to generate the SVG structure of the chart
   classNames: {
-    chart: 'ct-chart-bar',
+    chart: 'ct-chart ct-chart-bar',
     horizontalBars: 'ct-horizontal-bars',
     label: 'ct-label',
     labelGroup: 'ct-labels',

--- a/src/charts/LineChart/LineChart.ts
+++ b/src/charts/LineChart/LineChart.ts
@@ -132,7 +132,7 @@ const defaultOptions = {
   reverseData: false,
   // Override the class names that get used to generate the SVG structure of the chart
   classNames: {
-    chart: 'ct-chart-line',
+    chart: 'ct-chart ct-chart-line',
     label: 'ct-label',
     labelGroup: 'ct-labels',
     series: 'ct-series',

--- a/src/charts/PieChart/PieChart.ts
+++ b/src/charts/PieChart/PieChart.ts
@@ -43,8 +43,8 @@ const defaultOptions = {
   chartPadding: 5,
   // Override the class names that are used to generate the SVG structure of the chart
   classNames: {
-    chartPie: 'ct-chart-pie',
-    chartDonut: 'ct-chart-donut',
+    chartPie: 'ct-chart ct-chart-pie',
+    chartDonut: 'ct-chart ct-chart-donut',
     series: 'ct-series',
     slicePie: 'ct-slice-pie',
     sliceDonut: 'ct-slice-donut',

--- a/src/styles/_settings.scss
+++ b/src/styles/_settings.scss
@@ -1,3 +1,4 @@
+@use "sass:list";
 @use "sass:math";
 
 // Scales for responsive SVG containers

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -112,20 +112,19 @@
     dominant-baseline: central;
   }
 
-  .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-start} {
+  .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-start},
+  .#{$ct-class-label}.#{$ct-class-vertical}.#{$ct-class-end},
+  .#{$ct-class-chart-bar}.#{$ct-class-horizontal-bars} .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-start} {
     @include ct-align-justify(flex-end, flex-start);
   }
 
-  .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-end} {
+  .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-end},
+  .#{$ct-class-chart-bar}.#{$ct-class-horizontal-bars} .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-end} {
     @include ct-align-justify(flex-start, flex-start);
   }
 
   .#{$ct-class-label}.#{$ct-class-vertical}.#{$ct-class-start} {
     @include ct-align-justify(flex-end, flex-end);
-  }
-
-  .#{$ct-class-label}.#{$ct-class-vertical}.#{$ct-class-end} {
-    @include ct-align-justify(flex-end, flex-start);
   }
 
   .#{$ct-class-chart-bar} .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-start} {
@@ -134,14 +133,6 @@
 
   .#{$ct-class-chart-bar} .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-end} {
     @include ct-align-justify(flex-start, center);
-  }
-
-  .#{$ct-class-chart-bar}.#{$ct-class-horizontal-bars} .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-start} {
-    @include ct-align-justify(flex-end, flex-start);
-  }
-
-  .#{$ct-class-chart-bar}.#{$ct-class-horizontal-bars} .#{$ct-class-label}.#{$ct-class-horizontal}.#{$ct-class-end} {
-    @include ct-align-justify(flex-start, flex-start);
   }
 
   .#{$ct-class-chart-bar}.#{$ct-class-horizontal-bars} .#{$ct-class-label}.#{$ct-class-vertical}.#{$ct-class-start} {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,31 +1,11 @@
 @import "settings";
 
-@mixin ct-responsive-svg-container($width: 100%, $ratio: $ct-container-ratio) {
-  display: block;
-  position: relative;
-  width: $width;
-
-  &:before {
-    display: block;
-    float: left;
-    content: "";
-    width: 0;
-    height: 0;
-    padding-bottom: $ratio * 100%;
+@function list-to-classes($list) {
+  $new-list: ();
+  @each $item in $list {
+    $new-list: list.append($new-list, #{"."}#{$item}, comma);
   }
-
-  &:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
-  > svg {
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
+  @return $new-list;
 }
 
 @mixin ct-align-justify($ct-text-align: $ct-text-align, $ct-text-justify: $ct-text-justify) {
@@ -186,9 +166,32 @@
   @include ct-chart();
 
   @if $ct-include-alternative-responsive-containers {
-    @for $i from 0 to list.length($ct-scales-names) {
-      .#{list.nth($ct-scales-names, $i + 1)} {
-        @include ct-responsive-svg-container($ratio: list.nth($ct-scales, $i + 1));
+    #{list-to-classes($ct-scales-names)} {
+      display: block;
+      position: relative;
+      width: 100%;
+      &:before {
+        display: block;
+        float: left;
+        content: "";
+        width: 0;
+        height: 0;
+      }
+      &:after {
+        content: "";
+        display: table;
+        clear: both;
+      }
+      > svg{
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+    }
+    @each $name in $ct-scales-names {
+      .#{$name}:before {
+        padding-bottom: list.nth($ct-scales, list.index($ct-scales-names, $name)) * 100%;
       }
     }
   }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -181,9 +181,9 @@
   }
 
   @if $ct-include-colored-series {
-    @for $i from 0 to length($ct-series-names) {
-      .#{$ct-class-series}-#{nth($ct-series-names, $i + 1)} {
-        $color: nth($ct-series-colors, $i + 1);
+    @for $i from 0 to list.length($ct-series-names) {
+      .#{$ct-class-series}-#{list.nth($ct-series-names, $i + 1)} {
+        $color: list.nth($ct-series-colors, $i + 1);
 
         @include ct-chart-series-color($color);
       }
@@ -195,9 +195,9 @@
   @include ct-chart();
 
   @if $ct-include-alternative-responsive-containers {
-    @for $i from 0 to length($ct-scales-names) {
-      .#{nth($ct-scales-names, $i + 1)} {
-        @include ct-responsive-svg-container($ratio: nth($ct-scales, $i + 1));
+    @for $i from 0 to list.length($ct-scales-names) {
+      .#{list.nth($ct-scales-names, $i + 1)} {
+        @include ct-responsive-svg-container($ratio: list.nth($ct-scales, $i + 1));
       }
     }
   }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -66,13 +66,13 @@
   stroke-width: $ct-donut-width;
 }
 
-@mixin ct-chart-series-color($color) {
+@mixin ct-chart-series-color($series) {
   .#{$ct-class-point}, .#{$ct-class-line}, .#{$ct-class-bar}, .#{$ct-class-slice-donut} {
-    stroke: $color;
+    stroke: var(--#{$ct-class-series}-#{$series}-color);
   }
 
   .#{$ct-class-slice-pie}, .#{$ct-class-area} {
-    fill: $color;
+    fill: var(--#{$ct-class-series}-#{$series}-color);
   }
 }
 
@@ -152,11 +152,17 @@
   }
 
   @if $ct-include-colored-series {
-    @for $i from 0 to list.length($ct-series-names) {
-      .#{$ct-class-series}-#{list.nth($ct-series-names, $i + 1)} {
+    .#{$ct-class-series} {
+      @for $i from 0 to list.length($ct-series-names) {
+        $series: list.nth($ct-series-names, $i + 1);
         $color: list.nth($ct-series-colors, $i + 1);
-
-        @include ct-chart-series-color($color);
+        
+        --#{$ct-class-series}-#{$series}-color: #{$color};
+      }
+    }
+    @each $series in $ct-series-names {
+      .#{$ct-class-series}-#{$series} {
+        @include ct-chart-series-color($series);
       }
     }
   }


### PR DESCRIPTION
This is a refactoring - the new CSS is functionally identical to the old. The primary reason for the changes is to reduce the size of the minimised CSS by nearly 20%, from 9038 bytes to 7370 bytes.

The other reason is to greatly simplify customizing series colors. Currently, the CSS styles to alter one series is:

```
.myclass .ct-series-a .ct-point, .myclass .ct-series-a .ct-line, .myclass .ct-series-a .ct-bar, .myclass .ct-series-a .ct-slice-donut {
  stroke: #123456;
}
.myclass .ct-series-a .ct-slice-pie, .myclass .ct-series-a .ct-area {
  fill: #123456;
}
```

Each additional custom series color duplicates the above over and over, adjusting for the series name.

With the new CSS variables, the required styles are:

```
.myclass .ct-series {
  --ct-series-a-color: #123456;
}
```

Each additional custom series color just duplicates the one color line, adjusting for the series name.

I have also added the "ct-chart" class name to all charts, to make it easier to write CSS rules that target all charts, in the same way there is a general "ct-series" class name.